### PR TITLE
Add specialized faults and HelpLink to Result class

### DIFF
--- a/src/Arcturus.ResultObjects/Result.cs
+++ b/src/Arcturus.ResultObjects/Result.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using Arcturus.ResultObjects.Specialized;
+using System.Net;
 
 namespace Arcturus.ResultObjects;
 
@@ -11,6 +12,10 @@ public class Result
     {
         IsSuccess = isSuccess;
         Fault = fault;
+        if (fault is ISpecializedFault specializedFault)
+        {
+            HttpStatusCode = specializedFault.HttpStatusCode;
+        }
     }
     
     /// <summary>
@@ -58,4 +63,8 @@ public class Result
     /// Gets an HttpStatusCode if assigned. Use <see cref="ResultExtensions.WithHttpStatusCode{T}(Result{T}, HttpStatusCode)"/>.
     /// </summary>
     public HttpStatusCode? HttpStatusCode { get; internal set; }
+    /// <summary>
+    /// Gets a url of a help documentation.
+    /// </summary>
+    public string? HelpLink { get; internal set; }
 }

--- a/src/Arcturus.ResultObjects/ResultExtensions.cs
+++ b/src/Arcturus.ResultObjects/ResultExtensions.cs
@@ -52,4 +52,9 @@ public static class ResultExtensions
         value.HttpStatusCode = httpStatusCode;
         return value;
     }
+    public static Result<T> WithHelpLink<T>(this Result<T> result, string uri)
+    {
+        result.HelpLink = uri;
+        return result;
+    }
 }

--- a/src/Arcturus.ResultObjects/Specialized/AmbiguousFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/AmbiguousFault.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public record AmbiguousFault(string Code, string Message)
+    : Fault(Code, Message), ISpecializedFault
+{
+    public HttpStatusCode HttpStatusCode => HttpStatusCode.Ambiguous;
+}

--- a/src/Arcturus.ResultObjects/Specialized/BadRequestFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/BadRequestFault.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public record BadRequestFault(string Code, string Message)
+    : Fault(Code, Message), ISpecializedFault
+{
+    public HttpStatusCode HttpStatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/Arcturus.ResultObjects/Specialized/ConflictFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/ConflictFault.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public record ConflictFault(string Code, string Message)
+    : Fault(Code, Message), ISpecializedFault
+{
+    public HttpStatusCode HttpStatusCode => HttpStatusCode.Conflict;
+}

--- a/src/Arcturus.ResultObjects/Specialized/ConstraintFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/ConstraintFault.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public record ConstraintFault(string Code, string Message)
+    : Fault(Code, Message), ISpecializedFault
+{
+    public HttpStatusCode HttpStatusCode => HttpStatusCode.UnprocessableContent;
+}

--- a/src/Arcturus.ResultObjects/Specialized/ForbiddenFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/ForbiddenFault.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public record ForbiddenFault(string Code, string Message)
+    : Fault(Code, Message), ISpecializedFault
+{
+    public HttpStatusCode HttpStatusCode => HttpStatusCode.Forbidden;
+}

--- a/src/Arcturus.ResultObjects/Specialized/ISpecializedFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/ISpecializedFault.cs
@@ -1,0 +1,8 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public interface ISpecializedFault
+{
+    HttpStatusCode HttpStatusCode { get; }
+}

--- a/src/Arcturus.ResultObjects/Specialized/PaymentFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/PaymentFault.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public record PaymentFault(string Code, string Message)
+    : Fault(Code, Message), ISpecializedFault
+{
+    public HttpStatusCode HttpStatusCode => HttpStatusCode.PaymentRequired;
+}

--- a/src/Arcturus.ResultObjects/Specialized/UnauthorizedFault.cs
+++ b/src/Arcturus.ResultObjects/Specialized/UnauthorizedFault.cs
@@ -1,0 +1,9 @@
+﻿using System.Net;
+
+namespace Arcturus.ResultObjects.Specialized;
+
+public record UnauthorizedFault(string Code, string Message)
+    : Fault(Code, Message), ISpecializedFault
+{
+    public HttpStatusCode HttpStatusCode => HttpStatusCode.Unauthorized;
+}


### PR DESCRIPTION
- Updated `Result.cs` to include `Arcturus.ResultObjects.Specialized` namespace.
- Added `HelpLink` property to `Result` class.
- Constructor now checks for `ISpecializedFault` and assigns `HttpStatusCode`.
- Added `WithHelpLink` extension method in `ResultExtensions.cs`.
- Introduced `ISpecializedFault` interface with `HttpStatusCode` property.
- Added specialized fault classes: `AmbiguousFault`, `BadRequestFault`, `ConflictFault`, `ConstraintFault`, `ForbiddenFault`, `PaymentFault`, `UnauthorizedFault`.