### PR TITLE
Refactor event bus and improve documentation

### DIFF
--- a/src/Arcturus.EventBus.Abstracts/EventMessageAttribute.cs
+++ b/src/Arcturus.EventBus.Abstracts/EventMessageAttribute.cs
@@ -1,0 +1,17 @@
+﻿namespace Arcturus.EventBus.Abstracts;
+
+/// <summary>
+/// Specifies properties of the integration event.
+/// <para>
+/// Use the <see cref="EventMessageAttribute"/> to override the name of the event.
+/// </para>
+/// </summary>
+/// <param name="name">Required. Name of the event for binding.</param>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+public sealed class EventMessageAttribute(string name) : Attribute
+{
+    /// <summary>
+    /// Gets the name of the event.
+    /// </summary>
+    public string Name { get; } = name;
+}

--- a/src/Arcturus.EventBus.Abstracts/IEventBusFactory.cs
+++ b/src/Arcturus.EventBus.Abstracts/IEventBusFactory.cs
@@ -1,7 +1,7 @@
 ﻿namespace Arcturus.EventBus.Abstracts;
 
 /// <summary>
-/// Provides methods to creates instances of <see cref="IProcessor"/>, <see cref="IPublisher"/>, and <see cref="ISubscriber"/>.
+/// Provides methods to creates instances of <see cref="IProcessor"/> and <see cref="IPublisher"/>.
 /// </summary>
 public interface IEventBusFactory
 {

--- a/src/Arcturus.EventBus.Abstracts/IPublisher.cs
+++ b/src/Arcturus.EventBus.Abstracts/IPublisher.cs
@@ -6,7 +6,7 @@
 public interface IPublisher
 {
     /// <summary>
-    /// Publishes an event via the event bus.
+    /// Publishes an <see cref="IEventMessage" /> via the event bus.
     /// </summary>
     /// <typeparam name="TEvent">Event type implemented by <see cref="IEventMessage"/></typeparam>
     /// <param name="event">Required. Event to publish.</param>

--- a/src/Arcturus.EventBus.RabbitMQ/Internals/DefaultEventMessageTypeResolver.cs
+++ b/src/Arcturus.EventBus.RabbitMQ/Internals/DefaultEventMessageTypeResolver.cs
@@ -1,9 +1,11 @@
-﻿namespace Arcturus.EventBus.RabbitMQ.Internals;
+﻿using Arcturus.EventBus.Abstracts;
+
+namespace Arcturus.EventBus.RabbitMQ.Internals;
 
 /// <summary>
 /// Default type resolver using the AppDomain.
 /// </summary>
-internal class DefaultEventMessageTypeResolver
+internal sealed class DefaultEventMessageTypeResolver
 {
     private readonly Dictionary<string, Type?> _reflectionCache = [];
 
@@ -12,6 +14,7 @@ internal class DefaultEventMessageTypeResolver
     /// </summary>
     /// <param name="typeName">Required. Name of type to resolve.</param>
     /// <returns><see cref="Type"/> or null.</returns>
+    /// <exception cref="InvalidOperationException">If more than one event has the same name.</exception>
     internal Type? ResolveType(string typeName)
     {
         ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
@@ -24,6 +27,19 @@ internal class DefaultEventMessageTypeResolver
             .Select(a => a.GetType(typeName))
             .Where(_ => _ is not null)
             .FirstOrDefault();
+        if (type is null)
+        {
+            // select single or default - an exception is thrown if more than one type is found
+            type = AppDomain.CurrentDomain
+                .GetAssemblies()
+                .SelectMany(a => a.GetTypes()) // Get all types from all assemblies
+                .Where(t => typeof(IEventMessage).IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract)
+                .SingleOrDefault(t =>
+                    t.GetCustomAttribute<EventMessageAttribute>() is EventMessageAttribute attr &&
+                    attr.Name == typeName);
+        }
+        // todo: implement more advanced type resolution (user delegates etc. from startup configuration)
+        // - alternatively allow overriding the type resolver to a custom resolver.
         if (type is not null)
         {
             _reflectionCache.Add(typeName, type);

--- a/src/Arcturus.EventBus.RabbitMQ/Internals/EventMessageConverter.cs
+++ b/src/Arcturus.EventBus.RabbitMQ/Internals/EventMessageConverter.cs
@@ -41,8 +41,8 @@ internal sealed class EventMessageConverter : JsonConverter<IEventMessage>
         var type = value.GetType();
         writer.WriteStartObject();
 
-        // Write the discriminator
-        writer.WriteString(DiscriminatorPropertyName, type.FullName);
+        // Write the discriminator (type)
+        writer.WriteString(DiscriminatorPropertyName, GetEventName(type));
 
         // Serialize the object properties
         var properties = type.GetProperties();
@@ -63,5 +63,13 @@ internal sealed class EventMessageConverter : JsonConverter<IEventMessage>
         }
 
         writer.WriteEndObject();
+    }
+    private static string GetEventName(Type type)
+    {
+        var messageAttribute = type.GetCustomAttribute<EventMessageAttribute>();
+        if (messageAttribute is not null)
+            return messageAttribute.Name;
+
+        return type.FullName!;
     }
 }

--- a/src/Arcturus.EventBus.RabbitMQ/RabbitMQEventBusFactory.cs
+++ b/src/Arcturus.EventBus.RabbitMQ/RabbitMQEventBusFactory.cs
@@ -19,11 +19,13 @@ public sealed class RabbitMQEventBusFactory(
     }
     public IProcessor CreateProcessor(string? queue = null)
     {
-        // returns a wrapper
+        // returns a wrapper processor that will handle the event handlers
+        // and fallback to the processor if no handlers are found
         if (_eventBusOptions.UseEventHandlersProcessor.GetValueOrDefault(true))
             return new EventHandlersProcessor(
                 new RabbitMQProcessor(_connection, queue), _serviceProvider, loggerFactory);
-        return new RabbitMQProcessor(connection, queue);
+
+        return new RabbitMQProcessor(_connection, queue);
     }
     //public ISubscriber CreateSubscriber()
     //{

--- a/src/Arcturus.EventBus.RabbitMQ/RabbitMQEventBusOptions.cs
+++ b/src/Arcturus.EventBus.RabbitMQ/RabbitMQEventBusOptions.cs
@@ -15,7 +15,10 @@ public sealed class RabbitMQEventBusOptions
     /// </summary>
     public string? HostName { get; set; }
     /// <summary>
-    /// If true, events will be processed by the event handlers processor and fallback to the <see cref="Arcturus.EventBus.Abstracts.IProcessor.OnProcessAsync"/> event.
+    /// If true, events will be processed by the <see cref="Arcturus.EventBus.EventHandlersProcessor"/> or fallback to the <see cref="Arcturus.EventBus.Abstracts.IProcessor.OnProcessAsync"/> event.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="Arcturus.EventBus.EventHandlersProcessor"/> provide support for event pipelines, which may implement <see cref="Arcturus.EventBus.Middleware.IEventMiddleware" />. Use <see cref="Arcturus.EventBus.Middleware.HostExtensions.UseEventMiddleware{TMiddleware}(Microsoft.Extensions.Hosting.IHost, object?[])"/>.
+    /// </remarks>
     public bool? UseEventHandlersProcessor { get; set; }
 }

--- a/src/Arcturus.EventBus.RabbitMQ/ServiceExtensions.cs
+++ b/src/Arcturus.EventBus.RabbitMQ/ServiceExtensions.cs
@@ -5,6 +5,12 @@ namespace Arcturus.EventBus.RabbitMQ;
 
 public static class ServicesExtensions
 {
+    /// <summary>
+    /// Adds RabbitMQ EventBus to the service collection.
+    /// </summary>
+    /// <param name="services">Service collection.</param>
+    /// <param name="options">Optional.</param>
+    /// <returns><see cref="IServiceCollection"/></returns>
     public static IServiceCollection AddRabbitMQEventBus(
         this IServiceCollection services
         , Action<RabbitMQEventBusOptions>? options = null)

--- a/src/Arcturus.EventBus/Diagnostics/IDiagnosticProperties.cs
+++ b/src/Arcturus.EventBus/Diagnostics/IDiagnosticProperties.cs
@@ -1,9 +1,27 @@
 ﻿namespace Arcturus.EventBus.Diagnostics;
 
+/// <summary>
+/// Represents diagnostic properties for an event bus message.
+/// </summary>
 public interface IDiagnosticProperties
 {
+    /// <summary>
+    /// Gets the application identifier.
+    /// </summary>
     string? AppId { get; }
+
+    /// <summary>
+    /// Gets the message identifier.
+    /// </summary>
     string? MessageId { get; }
+
+    /// <summary>
+    /// Gets the correlation identifier.
+    /// </summary>
     string? CorrelationId { get; }
+
+    /// <summary>
+    /// Gets the headers associated with the message.
+    /// </summary>
     IDictionary<string, object?>? Headers { get; }
 }

--- a/src/Arcturus.EventBus/EventHandlersProcessor.cs
+++ b/src/Arcturus.EventBus/EventHandlersProcessor.cs
@@ -54,6 +54,9 @@ public sealed class EventHandlersProcessor : IProcessor
             return;
         }
 
+        // initiate a scope for the pipeline
+        // - the scopes service provider is passed onto the eventhandler
+#pragma warning disable IDE0063 // Use simple 'using' statement
         using (var scope = _serviceProvider.CreateScope())
         {
             var pipeline = HostExtensions.BuildByRequestDelegate(
@@ -70,5 +73,6 @@ public sealed class EventHandlersProcessor : IProcessor
 
             await pipeline(new EventContext(@event, nameof(@event), scope.ServiceProvider));
         }
+#pragma warning restore IDE0063 // Use simple 'using' statement
     }
 }

--- a/src/Arcturus.EventBus/Middleware/HostExtensions.cs
+++ b/src/Arcturus.EventBus/Middleware/HostExtensions.cs
@@ -13,13 +13,20 @@ public static class HostExtensions
     private readonly static MethodInfo _getServiceInfo
         = typeof(HostExtensions).GetMethod(nameof(GetService), BindingFlags.NonPublic | BindingFlags.Static)!;
 
-    public static IHost UseMiddleware<TMiddleware>(
+    /// <summary>
+    /// Injects an event middleware into the event pipeline.
+    /// </summary>
+    /// <typeparam name="TMiddleware"></typeparam>
+    /// <param name="app"></param>
+    /// <param name="args"></param>
+    /// <returns></returns>
+    public static IHost UseEventMiddleware<TMiddleware>(
         this IHost app, params object?[] args) where TMiddleware : IEventMiddleware
     {
-        return app.UseMiddleware(typeof(TMiddleware), args);
+        return app.UseEventMiddleware(typeof(TMiddleware), args);
     }
 
-    private static IHost UseMiddleware(
+    private static IHost UseEventMiddleware(
         this IHost app
         , Type middleware
         , params object?[] args)
@@ -87,7 +94,7 @@ public static class HostExtensions
         private readonly MethodInfo _invokeMethod;
         private readonly ParameterInfo[] _parameters;
 
-        public ReflectionMiddlewareBinder(
+        internal ReflectionMiddlewareBinder(
             IHost app,
             Type middleware,
             object?[] args,
@@ -102,7 +109,7 @@ public static class HostExtensions
         }
 
         // The CreateMiddleware method name is used by ApplicationBuilder to resolve the middleware type.
-        public RequestDelegate CreateMiddleware(RequestDelegate next)
+        internal RequestDelegate CreateMiddleware(RequestDelegate next)
         {
             var ctorArgs = new object[_args.Length + 1];
             ctorArgs[0] = next;

--- a/src/Arcturus.EventBus/Middleware/IEventMiddleware.cs
+++ b/src/Arcturus.EventBus/Middleware/IEventMiddleware.cs
@@ -1,6 +1,14 @@
 ﻿namespace Arcturus.EventBus.Middleware;
 
+/// <summary>
+/// Defines a middleware component that can process events in the event bus pipeline.
+/// </summary>
 public interface IEventMiddleware
 {
+    /// <summary>
+    /// Executes the middleware logic asynchronously.
+    /// </summary>
+    /// <param name="context">The context for the event being processed.</param>
+    /// <returns>A <see cref="Task" /> that represents the asynchronous operation.</returns>
     Task InvokeAsync(EventContext context);
 }

--- a/src/Arcturus.EventBus/Middleware/RequestDelegate.cs
+++ b/src/Arcturus.EventBus/Middleware/RequestDelegate.cs
@@ -1,3 +1,8 @@
 ﻿namespace Arcturus.EventBus.Middleware;
 
+/// <summary>
+/// Represents a method that can process an event in the event bus middleware.
+/// </summary>
+/// <param name="context">The context of the event being processed.</param>
+/// <returns>A <see cref="Task" /> that represents the completion of the event processing.</returns>
 public delegate Task RequestDelegate(EventContext context);

--- a/src/Arcturus.EventBus/Threading/AsyncLock.cs
+++ b/src/Arcturus.EventBus/Threading/AsyncLock.cs
@@ -1,15 +1,26 @@
 ﻿namespace Arcturus.EventBus.Threading;
 
+/// <summary>
+/// Provides an asynchronous lock mechanism to ensure that only one thread can access a resource at a time.
+/// </summary>
 public sealed class AsyncLock
 {
     private readonly SemaphoreSlim _semaphore = new(1, 1);
 
+    /// <summary>
+    /// Asynchronously waits to enter the lock. Returns an <see cref="IDisposable"/> that releases the lock when disposed.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token to observe while waiting for the lock.</param>
+    /// <returns>An <see cref="IDisposable"/> that releases the lock when disposed.</returns>
     public async Task<IDisposable> LockAsync(CancellationToken cancellationToken = default)
     {
         await _semaphore.WaitAsync(cancellationToken);
         return new Releaser(_semaphore);
     }
 
+    /// <summary>
+    /// A helper class that releases the semaphore when disposed.
+    /// </summary>
     private sealed class Releaser : IDisposable
     {
         private readonly SemaphoreSlim _semaphore;
@@ -19,6 +30,9 @@ public sealed class AsyncLock
             _semaphore = semaphore;
         }
 
+        /// <summary>
+        /// Releases the semaphore.
+        /// </summary>
         public void Dispose()
         {
             _semaphore.Release();


### PR DESCRIPTION
Updated various interfaces and classes to enhance documentation, improve type resolution, and use event names instead of type names. Key changes include:

- `IEventBusFactory`, `IPublisher`, `RabbitMQEventBusOptions`, `IDiagnosticProperties`, `IEventMiddleware`, `RequestDelegate`, and `AsyncLock` interfaces/classes received documentation updates.
- `DefaultEventMessageTypeResolver` now includes a `using` directive, is sealed, and has an advanced type resolution mechanism.
- `EventMessageConverter` and `RabbitMQPublisher` now use event names and include a `GetEventName` method.
- `RabbitMQEventBusFactory` and `EventHandlersProcessor` received comments and corrections.
- `HostExtensions` renamed `UseMiddleware` to `UseEventMiddleware` and changed method visibility.
- Added new `EventMessageAttribute` class to specify integration event properties.