### PR TITLE
Refactor Result classes and improve documentation

### DIFF
--- a/src/Arcturus.ResultObjects/Result.cs
+++ b/src/Arcturus.ResultObjects/Result.cs
@@ -8,7 +8,12 @@ namespace Arcturus.ResultObjects;
 /// </summary>
 public class Result
 {
-    internal Result(bool isSuccess, Fault? fault = null)
+    /// <summary>
+    /// Creates a new instance of <see cref="Result"/> with a <paramref name="fault"/> and <paramref name="isSuccess"/>.
+    /// </summary>
+    /// <param name="isSuccess">A value of <see cref="bool"/> indicating is the result represens success.</param>
+    /// <param name="fault">Optional <see cref="ResultObjects.Fault"/> if <paramref name="isSuccess"/> is false.</param>
+    protected Result(bool isSuccess, Fault? fault = null)
     {
         IsSuccess = isSuccess;
         Fault = fault;
@@ -29,7 +34,7 @@ public class Result
     /// <typeparam name="TValue">Type of value.</typeparam>
     /// <param name="value">Optional. Value of result.</param>
     /// <returns><see cref="Result{T}"/></returns>
-    public static Result<TValue> Success<TValue>(TValue? value) => new(true, value);
+    public static Result<TValue> Success<TValue>(TValue? value) => Result<TValue>.Create(true, value);
     /// <summary>
     /// Returns a failure result with an optional <paramref name="fault"/>.
     /// </summary>
@@ -42,7 +47,7 @@ public class Result
     /// <typeparam name="TValue">Type of value.</typeparam>
     /// <param name="fault">Optional.</param>
     /// <returns><see cref="Result{T}"/></returns>
-    public static Result<TValue> Failure<TValue>(Fault? fault = null) => new(false, default, fault);
+    public static Result<TValue> Failure<TValue>(Fault? fault = null) => Result<TValue>.Create(false, default, fault);
     /// <summary>
     /// Returns a failure result with a fault of <paramref name="code"/> and <paramref name="message"/>
     /// </summary>
@@ -50,7 +55,7 @@ public class Result
     /// <param name="code">Optional code.</param>
     /// <param name="message">Message of the fault.</param>
     /// <returns><see cref="Result{T}"/></returns>
-    public static Result<TValue> Failure<TValue>(string? code, string message) => new(false, default, new Fault(code, message));
+    public static Result<TValue> Failure<TValue>(string? code, string message) => Result<TValue>.Create(false, default, new Fault(code, message));
     /// <summary>
     /// Returns true if the result is a success.
     /// </summary>

--- a/src/Arcturus.ResultObjects/ResultOfT.cs
+++ b/src/Arcturus.ResultObjects/ResultOfT.cs
@@ -4,12 +4,21 @@
 /// Represents a result of an operation - success or failure.
 /// </summary>
 /// <typeparam name="T">Type fo containing result.</typeparam>
-public sealed class Result<T> : Result
+public class Result<T> : Result
 {
-    internal Result(bool isSuccess, T? value, Fault? fault = null) : base(isSuccess, fault)
+    /// <summary>
+    /// Creates a new instance of <see cref="Result{T}"/> with a <paramref name="fault"/> and <paramref name="isSuccess"/>.
+    /// </summary>
+    /// <param name="isSuccess">A value of <see cref="bool"/> indicating is the result represens success.</param>
+    /// <param name="value">Optional value of <typeparamref name="T"/> to assign.</param>
+    /// <param name="fault">Optional <see cref="ResultObjects.Fault"/> if <paramref name="isSuccess"/> is false.</param>
+    protected Result(bool isSuccess, T? value, Fault? fault = null) : base(isSuccess, fault)
     {
         Value = value;
     }
+
+    internal static Result<T> Create(bool isSuccess, T? value, Fault? fault = null) => new(isSuccess, value, fault);
+
     /// <summary>
     /// Returns value of result or null.
     /// </summary>


### PR DESCRIPTION
- Changed namespace for `Result` class to `Arcturus.ResultObjects`.
- Updated `Result` constructor to be `protected` and added XML documentation.
- Modified `Success<TValue>` and `Failure<TValue>` methods to use a new `Create` method for instantiation.
- Changed `Result<T>` from `sealed` to `public` to allow inheritance.
- Enhanced `Result<T>` constructor with XML documentation and made it `protected`.
- Added a new static `Create` method to `Result<T>` for structured instance creation.
- Overall improvements to documentation and code structure for better consistency.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
