### PR TITLE
Refactor XML documentation packaging in project files

### DIFF
--- a/src/Arcturus.EventBus.Abstracts/Arcturus.EventBus.Abstracts.csproj
+++ b/src/Arcturus.EventBus.Abstracts/Arcturus.EventBus.Abstracts.csproj
@@ -7,7 +7,11 @@
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 
 	</PropertyGroup>
-	<ItemGroup>
-		<None Include="bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml" Pack="true" PackagePath="lib\$(TargetFramework)" />
-	</ItemGroup>
+	<Target Name="IncludeXmlDocsInPackage" AfterTargets="Build">
+		<ItemGroup Condition="Exists('$(OutputPath)$(AssemblyName).xml')">
+			<None Include="$(OutputPath)$(AssemblyName).xml"
+				  Pack="true"
+				  PackagePath="lib\$(TargetFramework)" />
+		</ItemGroup>
+	</Target>
 </Project>

--- a/src/Arcturus.EventBus.AzureServiceBus/Arcturus.EventBus.AzureServiceBus.csproj
+++ b/src/Arcturus.EventBus.AzureServiceBus/Arcturus.EventBus.AzureServiceBus.csproj
@@ -17,8 +17,12 @@
 	<ItemGroup>
 		<ProjectReference Include="..\Arcturus.EventBus\Arcturus.EventBus.csproj" />
 	</ItemGroup>
-	<ItemGroup>
-		<None Include="bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml" Pack="true" PackagePath="lib\$(TargetFramework)" />
-	</ItemGroup>
+	<Target Name="IncludeXmlDocsInPackage" AfterTargets="Build">
+		<ItemGroup Condition="Exists('$(OutputPath)$(AssemblyName).xml')">
+			<None Include="$(OutputPath)$(AssemblyName).xml"
+				  Pack="true"
+				  PackagePath="lib\$(TargetFramework)" />
+		</ItemGroup>
+	</Target>
 
 </Project>


### PR DESCRIPTION
Removed static XML documentation references and added a new target `IncludeXmlDocsInPackage` to conditionally include XML files in the package if they exist in the output path. This improves the packaging process by ensuring only available documentation is included.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [ ] I have added tests, or done manual regression tests
- [ ] I have updated the documentation, if necessary
