### PR TITLE
Add custom ProblemDetailsFactory and error mappings

### DIFF
--- a/src/Arcturus.Extensions.ResultObjects.AspNetCore/ArcturusAspNetCoreProblemDetailsFactory.cs
+++ b/src/Arcturus.Extensions.ResultObjects.AspNetCore/ArcturusAspNetCoreProblemDetailsFactory.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Arcturus.Extensions.ResultObjects.AspNetCore;
+
+public sealed class ArcturusAspNetCoreProblemDetailsFactory : ProblemDetailsFactory
+{
+    private readonly ApiBehaviorOptions _options;
+    private readonly IHostEnvironment _environment;
+
+    public ArcturusAspNetCoreProblemDetailsFactory(
+        IOptions<ApiBehaviorOptions> options,
+        IHostEnvironment environment)
+    {
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+        _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+    }
+
+    public override ProblemDetails CreateProblemDetails(
+        HttpContext httpContext,
+        int? statusCode = null,
+        string? title = null,
+        string? type = null,
+        string? detail = null,
+        string? instance = null)
+    {
+        statusCode ??= 500;
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Type = type,
+            Detail = detail,
+            Instance = instance
+        };
+
+        ApplyDefaults(httpContext, problemDetails, statusCode.Value);
+        return problemDetails;
+    }
+
+    public override ValidationProblemDetails CreateValidationProblemDetails(
+        HttpContext httpContext,
+        ModelStateDictionary modelStateDictionary,
+        int? statusCode = null,
+        string? title = null,
+        string? type = null,
+        string? detail = null,
+        string? instance = null)
+    {
+        if (modelStateDictionary == null)
+        {
+            throw new ArgumentNullException(nameof(modelStateDictionary));
+        }
+
+        statusCode ??= 400;
+
+        var problemDetails = new ValidationProblemDetails(modelStateDictionary)
+        {
+            Status = statusCode,
+            Type = type,
+            Detail = detail,
+            Instance = instance,
+            Title = title
+        };
+
+        ApplyDefaults(httpContext, problemDetails, statusCode.Value);
+        return problemDetails;
+    }
+
+    private void ApplyDefaults(HttpContext httpContext, ProblemDetails problemDetails, int statusCode)
+    {
+        problemDetails.Status ??= statusCode;
+
+        //var x = new ApiBehaviorOptions().ClientErrorMapping.
+        // Add default title and type from RFC if not provided
+        if (_options.ClientErrorMapping.TryGetValue(statusCode, out var clientErrorData))
+        {
+            problemDetails.Title ??= clientErrorData.Title;
+            problemDetails.Type ??= clientErrorData.Link;
+        }
+        else
+        {
+            problemDetails.Type ??= $"https://httpstatuses.io/{statusCode}";
+            problemDetails.Title ??= $"HTTP {statusCode}";
+        }
+
+        // Instance URI
+        problemDetails.Instance ??= httpContext.Request.Path;
+
+        // Add trace ID or correlation ID
+        string traceId = httpContext.TraceIdentifier;
+        if (httpContext.Request.Headers.TryGetValue("X-Correlation-ID", out var correlationId))
+        {
+            problemDetails.Extensions["correlationId"] = correlationId.ToString();
+        }
+        else if (!string.IsNullOrEmpty(traceId))
+        {
+            problemDetails.Extensions["correlationId"] = traceId;
+        }
+        if (traceId != null)
+        {
+            problemDetails.Extensions["traceId"] = traceId;
+        }
+
+        // Include detailed errors only in Development
+        if (_environment.IsDevelopment())
+        {
+            if (httpContext.Features.Get<IExceptionHandlerFeature>()?.Error is Exception ex)
+            {
+                problemDetails.Extensions["exception"] = new
+                {
+                    message = ex.Message,
+                    type = ex.GetType().FullName,
+                    stackTrace = ex.StackTrace?.Split(Environment.NewLine)
+                };
+            }
+        }
+    }
+}

--- a/src/Arcturus.Extensions.ResultObjects.AspNetCore/Results/ProblemDetailsResult.cs
+++ b/src/Arcturus.Extensions.ResultObjects.AspNetCore/Results/ProblemDetailsResult.cs
@@ -18,26 +18,16 @@ public sealed class ProblemDetailsResult : IResult
         HttpStatusCode defaultStatusCode = _result.HttpStatusCode ?? HttpStatusCode.BadRequest;
 
         var factory = httpContext.RequestServices.GetService<ProblemDetailsFactory>();
+        if (factory is null)
+            throw new ArgumentNullException("ProblemDetailsFactory is not registered in the service collection.");
+
         var problemDetails = factory!.CreateProblemDetails(httpContext, (int)defaultStatusCode);
 
         problemDetails.Title ??= _result.Fault?.Code;
         problemDetails.Detail = _result.Fault?.Message;
         problemDetails.Type ??= "https://schemas/2022/fault/#" + defaultStatusCode.ToString().ToLower();
         problemDetails.Instance = $"{httpContext.Request.Method} {httpContext.Request.Path}";
-        //var cts = new ProblemDetailsContext()
-        //{
-        //    HttpContext = httpContext
-        //};
-        //cts.ProblemDetails.Detail = _result.Fault?.Message;
-        //cts.ProblemDetails.Title = cts.ProblemDetails.Title ?? _result.Fault?.Code;
-        //cts.ProblemDetails.Extensions.Add("code", _value?.Code);
-        //if (_properties?.Length > 0)
-        //{
-        //    cts.ProblemDetails.Extensions
-        //        .Add("fields", _properties.ToKeyValueList(_ => _.Code, _ => _.Message));
-        //}
-        // TODO: add help link here
-        //    httpContext.Response.Clear();
+
         httpContext.Response.StatusCode = (int)defaultStatusCode;
         return HttpResultsHelper.WriteResultAsJsonAsync(
             httpContext

--- a/src/Arcturus.Extensions.ResultObjects.AspNetCore/ServiceExtensions.cs
+++ b/src/Arcturus.Extensions.ResultObjects.AspNetCore/ServiceExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Arcturus.Extensions.ResultObjects.AspNetCore;
 
@@ -17,7 +19,38 @@ public static class ServiceExtensions
         this IServiceCollection services
         , Action<Microsoft.AspNetCore.Http.ProblemDetailsOptions>? configureProblemDetailsOptions = null)
     {
-        services.AddProblemDetails(configureProblemDetailsOptions);
+        services.AddSingleton<ProblemDetailsFactory, ArcturusAspNetCoreProblemDetailsFactory>();
+        //services.AddProblemDetails(configureProblemDetailsOptions);
+
+        services.Configure<ApiBehaviorOptions>(options =>
+        {
+            var mappings = new Dictionary<int, (string Title, string Link)>
+            {
+                [400] = ("Bad Request", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1"),
+                [401] = ("Unauthorized", "https://datatracker.ietf.org/doc/html/rfc7235#section-3.1"),
+                [403] = ("Forbidden", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3"),
+                [404] = ("Not Found", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4"),
+                [405] = ("Method Not Allowed", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5"),
+                [406] = ("Not Acceptable", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6"),
+                [409] = ("Conflict", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.8"),
+                [415] = ("Unsupported Media Type", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13"),
+                [422] = ("Unprocessable Entity", "https://datatracker.ietf.org/doc/html/rfc4918#section-11.2"),
+                [429] = ("Too Many Requests", "https://datatracker.ietf.org/doc/html/rfc6585#section-4"),
+                [500] = ("Internal Server Error", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1"),
+                [501] = ("Not Implemented", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.2"),
+                [502] = ("Bad Gateway", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.3"),
+                [503] = ("Service Unavailable", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.4"),
+                [504] = ("Gateway Timeout", "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.5")
+            };
+            foreach (var (statusCode, data) in mappings)
+            {
+                options.ClientErrorMapping[statusCode] = new ClientErrorData
+                {
+                    Title = data.Title,
+                    Link = data.Link
+                };
+            }
+        });
         return services;
     }
 }


### PR DESCRIPTION
Introduces `ArcturusAspNetCoreProblemDetailsFactory` to provide custom implementations for `ProblemDetails` and `ValidationProblemDetails`. Updates `UseResultObjects` to register the factory and configure client error mappings for various HTTP status codes. Modifies `ExecuteAsync` in `ProblemDetailsResult` to check for the factory's registration and removes commented-out code for clarity.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
