### PR TITLE
Add specification pattern support to repository classes

### DIFF
--- a/src/Arcturus.Data.Repository.Abstracts/IRepository.cs
+++ b/src/Arcturus.Data.Repository.Abstracts/IRepository.cs
@@ -120,4 +120,18 @@ public interface IRepository<T, TKey>
         , Expression<Func<T, R>> select
         , bool tracking = false
         , CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Finds a single entity that matches the specified predicate and projects it to the specified result type.
+    /// </summary>
+    /// <param name="specification">A given <see cref="Specification{T}"/> to use for query.</param>
+    /// <param name="tracking">A value indicating whether the entity should be tracked by the context.  <see langword="true"/> to enable
+    /// tracking; otherwise, <see langword="false"/>.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the projected entity  of type
+    /// <typeparamref name="T"/>, or <see langword="null"/> if no entity matches the predicate.</returns>
+    /// <exception cref="NotImplementedException" />
+    Task<T?> FindOne(
+        Specification<T> specification
+        , bool tracking = false
+        , CancellationToken cancellationToken = default);
 }

--- a/src/Arcturus.Data.Repository.Abstracts/IncludableSpecificationBuilder.cs
+++ b/src/Arcturus.Data.Repository.Abstracts/IncludableSpecificationBuilder.cs
@@ -1,0 +1,163 @@
+﻿using System.Linq.Expressions;
+
+namespace Arcturus.Data.Repository.Abstracts;
+
+public sealed class IncludableSpecificationBuilder<TEntity, TProperty>
+{
+    internal List<string> IncludePaths { get; } = new();
+    internal Expression<Func<TEntity, object>> CurrentInclude { get; }
+
+    public IncludableSpecificationBuilder(Expression<Func<TEntity, object>> include)
+    {
+        CurrentInclude = include;
+    }
+}
+
+// version 2
+//public abstract class SpecificationExecutor<T>(Specification<T> specification)
+//{
+//    protected Specification<T> Specification { get; } = specification;
+//    public abstract IQueryable<T> Apply(IQueryable<T> queryable);
+//}
+
+//public class Specification<T>(Expression<Func<T, bool>> predicate)
+//{
+//    private readonly Expression<Func<T, bool>> _predicate = predicate;
+//    private readonly List<Expression<Func<T, object>>> _includes = new();
+
+//    public Expression<Func<T, bool>> Predicate => _predicate;
+//    public IEnumerable<Expression<Func<T, object>>> Includes => _includes;
+
+//    internal void AddInclude(Expression<Func<T, object>> includeExpression)
+//    {
+//        _includes.Add(includeExpression);
+//    }
+//}
+
+
+//public class IncludableSpecificationBuilder<TEntity, TProperty>
+//{
+//    internal List<string> IncludePaths { get; } = new();
+//    internal Expression<Func<TEntity, object>> CurrentInclude { get; }
+
+//    public IncludableSpecificationBuilder(Expression<Func<TEntity, object>> include)
+//    {
+//        CurrentInclude = include;
+//    }
+//}
+
+//public static class SpecificationExtensions
+//{
+//    public static IncludableSpecificationBuilder<TEntity, TProperty> Include<TEntity, TProperty>(
+//        this Specification<TEntity> spec,
+//        Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+//        where TEntity : class
+//    {
+//        var includeAsObject = Expression.Lambda<Func<TEntity, object>>(
+//            Expression.Convert(navigationPropertyPath.Body, typeof(object)),
+//            navigationPropertyPath.Parameters);
+
+//        spec.AddInclude(includeAsObject);
+//        return new IncludableSpecificationBuilder<TEntity, TProperty>(includeAsObject);
+//    }
+
+//    // These are no-ops, only syntactic sugar in this mock. EF Core's real ThenInclude is used when the IQueryable is executed.
+//    public static IncludableSpecificationBuilder<TEntity, TNextProperty> ThenInclude<TEntity, TPreviousProperty, TNextProperty>(
+//        this IncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> source,
+//        Expression<Func<TPreviousProperty, TNextProperty>> navigationPropertyPath)
+//    {
+//        // Optionally track the include chain if needed
+//        return new IncludableSpecificationBuilder<TEntity, TNextProperty>(source.CurrentInclude);
+//    }
+
+//    public static IncludableSpecificationBuilder<TEntity, TNextProperty> ThenInclude<TEntity, TPreviousProperty, TNextProperty>(
+//        this IncludableSpecificationBuilder<TEntity, TPreviousProperty> source,
+//        Expression<Func<TPreviousProperty, TNextProperty>> navigationPropertyPath)
+//    {
+//        return new IncludableSpecificationBuilder<TEntity, TNextProperty>(source.CurrentInclude);
+//    }
+
+//    private static Expression<Func<T, bool>> AsQueryable<T>(this Func<T, bool> predicate)
+//    {
+//        var param = Expression.Parameter(typeof(T));
+//        var body = Expression.Invoke(Expression.Constant(predicate), param);
+//        return Expression.Lambda<Func<T, bool>>(body, param);
+//    }
+//}
+
+// version 1
+//public sealed class Specification<T>(Expression<Func<T, bool>> predicate)
+//{
+//    private readonly Expression<Func<T, bool>> _predicate = predicate;
+//    private readonly List<Expression<Func<T, object>>> _includes = new();
+
+//    internal Expression<Func<T, bool>> Predicate => _predicate;
+//    internal IEnumerable<Expression<Func<T, object>>> Includes => _includes;
+
+//    internal void AddInclude(Expression<Func<T, object>> includeExpression)
+//    {
+//        _includes.Add(includeExpression);
+//    }
+
+//    internal IQueryable<T> ApplySpecification(IQueryable<T> queryable)
+//    {
+//        foreach (var include in _includes)
+//        {
+//            queryable = queryable.Include(include);
+//        }
+
+//        return queryable.Where(_predicate);
+//    }
+//}
+
+//public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity>;
+
+//public class Test()
+//{
+//    public void Ko()
+//    {
+//        var specification = new Specification<ClassKo>(x => x.Id == 38);
+//        specification.Include(_ => _.CDO).ThenInclude(_ => _.Ko);
+
+//    }
+//}
+
+//public static class SpecificationExtensions
+//{
+//    public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+//        this IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
+//        Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+//        where TEntity : class
+//    {
+//    }
+//    public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
+//        this IIncludableQueryable<TEntity, TPreviousProperty> source,
+//        Expression<Func<TPreviousProperty, TProperty>> navigationPropertyPath)
+//        where TEntity : class
+//    {
+//    }
+//    public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TProperty>(
+//        this Specification<TEntity> source
+//        , Expression<Func<TEntity, TProperty>> navigationPropertyPath) where TEntity : class
+//    {
+//        //source.Add(navigationPropertyPath);
+//        //Microsoft.EntityFrameworkCore.Utilities.Check.NotNull(navigationPropertyPath, "navigationPropertyPath");
+//        //return new IncludableQueryable<TEntity, TProperty>((IQueryable<TEntity>)((source.Provider is EntityQueryProvider) ? ((IQueryable<object>)source.Provider.CreateQuery<TEntity>(Expression.Call(null, IncludeMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TProperty)), new Expression[2]
+//        //{
+//        //    source.Expression,
+//        //    Expression.Quote(navigationPropertyPath)
+//        //}))) : ((IQueryable<object>)source)));
+//    }
+//}
+
+//public class ClassKo : IEntity<int>
+//{
+//    public int Id { get; set; }
+//    public ClassDo CDO { get; set; }
+//}
+//public class ClassDo : IEntity<int>
+//{
+//    public int Id { get; set; }
+//    public ClassKo Ko { get; set; }
+
+//}

--- a/src/Arcturus.Data.Repository.Abstracts/Specification.cs
+++ b/src/Arcturus.Data.Repository.Abstracts/Specification.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq.Expressions;
+
+namespace Arcturus.Data.Repository.Abstracts;
+
+/// <summary>
+/// Represents a specification that defines criteria for querying objects of type <typeparamref name="T"/>.
+/// </summary>
+/// <remarks>A specification encapsulates a predicate expression that determines whether an object satisfies the
+/// criteria. It also supports including related properties for eager loading in query scenarios.</remarks>
+/// <typeparam name="T">The type of object to which the specification applies.</typeparam>
+/// <param name="predicate"></param>
+public sealed class Specification<T>(Expression<Func<T, bool>> predicate)
+{
+    private readonly Expression<Func<T, bool>> _predicate = predicate;
+    private readonly List<Expression<Func<T, object>>> _includes = [];
+
+    public Expression<Func<T, bool>> Predicate => _predicate;
+    public IEnumerable<Expression<Func<T, object>>> Includes => _includes;
+
+    internal void AddInclude(Expression<Func<T, object>> includeExpression)
+    {
+        _includes.Add(includeExpression);
+    }
+}

--- a/src/Arcturus.Data.Repository.Abstracts/SpecificationExecutor.cs
+++ b/src/Arcturus.Data.Repository.Abstracts/SpecificationExecutor.cs
@@ -1,0 +1,9 @@
+﻿namespace Arcturus.Data.Repository.Abstracts;
+
+public abstract class SpecificationExecutor<TEntity>(Specification<TEntity> specification)
+    where TEntity : class
+{
+    protected readonly Specification<TEntity> Specification = specification;
+
+    public abstract IQueryable<TEntity> Apply(IQueryable<TEntity> source);
+}

--- a/src/Arcturus.Data.Repository.Abstracts/SpecificationExtensions.cs
+++ b/src/Arcturus.Data.Repository.Abstracts/SpecificationExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq.Expressions;
+
+namespace Arcturus.Data.Repository.Abstracts;
+
+public static class SpecificationExtensions
+{
+    /// <summary>
+    /// Adds a navigation property to the specification, enabling eager loading of related entities.
+    /// </summary>
+    /// <remarks>Use this method to specify related entities that should be included in the query results.
+    /// This is particularly useful for scenarios where lazy loading is disabled or when optimizing performance by
+    /// reducing the number of database queries.</remarks>
+    /// <typeparam name="TEntity">The type of the entity being queried.</typeparam>
+    /// <typeparam name="TProperty">The type of the navigation property to include.</typeparam>
+    /// <param name="spec">The specification to which the navigation property will be added.</param>
+    /// <param name="navigationPropertyPath">An expression representing the navigation property to include. For example, <c>x => x.Property</c>.</param>
+    /// <returns>An <see cref="IncludableSpecificationBuilder{TEntity, TProperty}"/> that allows chaining additional
+    /// configuration for the included navigation property.</returns>
+    public static IncludableSpecificationBuilder<TEntity, TProperty> Include<TEntity, TProperty>(
+        this Specification<TEntity> spec,
+        Expression<Func<TEntity, TProperty>> navigationPropertyPath)
+        where TEntity : class
+    {
+        var includeAsObject = Expression.Lambda<Func<TEntity, object>>(
+            Expression.Convert(navigationPropertyPath.Body, typeof(object)),
+            navigationPropertyPath.Parameters);
+
+        spec.AddInclude(includeAsObject);
+        return new IncludableSpecificationBuilder<TEntity, TProperty>(includeAsObject);
+    }
+
+    public static IncludableSpecificationBuilder<TEntity, TNextProperty> ThenInclude<TEntity, TPreviousProperty, TNextProperty>(
+        this IncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> source,
+        Expression<Func<TPreviousProperty, TNextProperty>> navigationPropertyPath)
+    {
+        // Optionally track the include chain if needed
+        return new IncludableSpecificationBuilder<TEntity, TNextProperty>(source.CurrentInclude);
+    }
+
+    public static IncludableSpecificationBuilder<TEntity, TNextProperty> ThenInclude<TEntity, TPreviousProperty, TNextProperty>(
+        this IncludableSpecificationBuilder<TEntity, TPreviousProperty> source,
+        Expression<Func<TPreviousProperty, TNextProperty>> navigationPropertyPath)
+    {
+        return new IncludableSpecificationBuilder<TEntity, TNextProperty>(source.CurrentInclude);
+    }
+
+    private static Expression<Func<T, bool>> AsQueryable<T>(this Func<T, bool> predicate)
+    {
+        var param = Expression.Parameter(typeof(T));
+        var body = Expression.Invoke(Expression.Constant(predicate), param);
+        return Expression.Lambda<Func<T, bool>>(body, param);
+    }
+}

--- a/src/Arcturus.Data.Repository.EntityFrameworkCore/Internals/SqlSpecificationExecutor.cs
+++ b/src/Arcturus.Data.Repository.EntityFrameworkCore/Internals/SqlSpecificationExecutor.cs
@@ -1,0 +1,19 @@
+﻿using Arcturus.Data.Repository.Abstracts;
+using Microsoft.EntityFrameworkCore;
+
+namespace Arcturus.Data.Repository.EntityFrameworkCore.Internals;
+
+internal sealed class SqlSpecificationExecutor<TEntity>(Specification<TEntity> specification) 
+    : SpecificationExecutor<TEntity>(specification)
+    where TEntity : class
+{
+    public override IQueryable<TEntity> Apply(IQueryable<TEntity> source)
+    {
+        foreach (var include in Specification.Includes)
+        {
+            source = source.AsQueryable().Include(include);
+        }
+
+        return source.Where(Specification.Predicate);
+    }
+}

--- a/src/Arcturus.Data.Repository.EntityFrameworkCore/Repository.cs
+++ b/src/Arcturus.Data.Repository.EntityFrameworkCore/Repository.cs
@@ -2,6 +2,7 @@
 using Arcturus.Data.Repository.Abstracts;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
+using Arcturus.Data.Repository.EntityFrameworkCore.Internals;
 
 namespace Arcturus.Data.Repository.EntityFrameworkCore;
 
@@ -115,5 +116,18 @@ public class Repository<T, TKey>(
         return await _context.Set<T>()
             .Where(predicate)
             .SingleOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<T?> FindOne(
+        Specification<T> specification
+        , bool tracking = false
+        , CancellationToken cancellationToken = default)
+    {
+        var exec = new SqlSpecificationExecutor<T>(specification);
+        var query = exec.Apply(_context.Set<T>());
+        if (tracking)
+            query = query.AsTracking();
+
+        return await query.SingleOrDefaultAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
- Introduced `FindOne<R>` method in `IRepository<T, TKey>` for entity retrieval with projection.
- Implemented `FindOne` in `Repository<T, TKey>` using `Specification<T>` for filtering and tracking.
- Added `IncludableSpecificationBuilder<TEntity, TProperty>` for managing related entity includes.
- Enhanced `Specification<T>` to support eager loading with include expressions.
- Defined `SpecificationExecutor<TEntity>` for executing specifications against queryables.
- Expanded `SpecificationExtensions` with methods for including navigation properties.
- Implemented `SqlSpecificationExecutor<TEntity>` to apply specifications to `IQueryable<TEntity>`.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
