### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,6 +3,10 @@
 
 name: Publish Nuget Packages
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_dispatch: ## manual
 


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfy/Arcturus/security/code-scanning/1](https://github.com/cloudfy/Arcturus/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with the repository contents and pushes packages to NuGet. Therefore, we will set `contents: read` and `packages: write` permissions. These permissions are sufficient for the workflow to perform its tasks while minimizing unnecessary access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
