### PR TITLE
Enhance event bus queue handling and documentation

### DIFF
--- a/src/Arcturus.EventBus.Abstracts/IEventBusFactory.cs
+++ b/src/Arcturus.EventBus.Abstracts/IEventBusFactory.cs
@@ -8,13 +8,13 @@ public interface IEventBusFactory
     /// <summary>
     /// Creates a new instance of <see cref="IProcessor"/>. Processors are used to process messages from the event bus asynchronously.
     /// </summary>
-    /// <param name="queue">Optional. Name of the queue.</param>
+    /// <param name="queue">Optional. Name of the queue. Defaults to default_queue.</param>
     /// <returns><see cref="IProcessor"/> instance.</returns>
     IProcessor CreateProcessor(string? queue = null);
     /// <summary>
     /// Creates a new instance of <see cref="IPublisher"/>. Publishers are used to publish messages to the event bus.
     /// </summary>
-    /// <param name="queue">Optional. Name of the queue.</param>
+    /// <param name="queue">Optional. Name of the queue. Defaults to default_queue.</param>
     /// <returns><see cref="IPublisher"/> instance.</returns>
     IPublisher CreatePublisher(string? queue = null);
     //ISubscriber CreateSubscriber();

--- a/src/Arcturus.EventBus.Sqlite/SqliteEventBusFactory.cs
+++ b/src/Arcturus.EventBus.Sqlite/SqliteEventBusFactory.cs
@@ -19,15 +19,15 @@ public sealed class SqliteEventBusFactory(
         // and fallback to the processor if no handlers are found
         if (_eventBusOptions.UseEventHandlersProcessor.GetValueOrDefault(true))
             return new EventHandlersProcessor(
-                new SqliteProcessor(_connection, queue, _eventBusOptions.ProcessInterval.GetValueOrDefault(100))
+                new SqliteProcessor(_connection, queue ?? _eventBusOptions.DefaultQueueName, _eventBusOptions.ProcessInterval.GetValueOrDefault(100))
                 , _serviceProvider
                 , loggerFactory);
 
-        return new SqliteProcessor(_connection, queue, _eventBusOptions.ProcessInterval.GetValueOrDefault(100));
+        return new SqliteProcessor(_connection, queue ?? _eventBusOptions.DefaultQueueName, _eventBusOptions.ProcessInterval.GetValueOrDefault(100));
     }
 
     public IPublisher CreatePublisher(string? queue = null)
     {
-        return new SqlitePublisher(_connection, loggerFactory, queue);
+        return new SqlitePublisher(_connection, loggerFactory, queue ?? _eventBusOptions.DefaultQueueName);
     }
 }

--- a/src/Arcturus.EventBus.Sqlite/SqliteEventBusOptions.cs
+++ b/src/Arcturus.EventBus.Sqlite/SqliteEventBusOptions.cs
@@ -11,6 +11,10 @@ public class SqliteEventBusOptions
     /// </summary>
     public string? ClientName { get; set; }
     /// <summary>
+    /// Gets or sets a default queue name. Queue name can also be specificed when creating the <see cref="Arcturus.EventBus.Abstracts.IProcessor"/> or <see cref="Arcturus.EventBus.Abstracts.IPublisher"/>, otherwise it will default to 'default_queue'.
+    /// </summary>
+    public string? DefaultQueueName { get; set; }
+    /// <summary>
     /// Gets or sets a host name. Defaults to <see cref="Environment.MachineName" />.
     /// </summary>
     public string? HostName { get; set; }


### PR DESCRIPTION
Updated IEventBusFactory to clarify default queue behavior. Modified SqliteEventBusFactory to use DefaultQueueName when the queue parameter is null. Added DefaultQueueName property to SqliteEventBusOptions for improved configuration flexibility.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
