### PR TITLE
Broaden type conversion in OrderByExpressionParser

### DIFF
--- a/src/Arcturus.Data.Repository.Abstracts/Specification/Parsing/Internals/OrderByExpressionParser.cs
+++ b/src/Arcturus.Data.Repository.Abstracts/Specification/Parsing/Internals/OrderByExpressionParser.cs
@@ -35,7 +35,7 @@ internal static class OrderByExpressionParser
             body = Expression.Property(body, prop);
         }
 
-        if (body.Type.IsValueType)
+        if (body.Type != typeof(object))
             body = Expression.Convert(body, typeof(object));
 
         return Expression.Lambda<Func<T, object?>>(body, parameter);


### PR DESCRIPTION
Changed the condition for converting property access expressions to object. Now, all types except object itself are converted, ensuring both value types and reference types (other than object) are handled consistently in generated expressions.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
