### PR TITLE
Add HttpClient analyzer project and SDA001 rule

### DIFF
--- a/Arcturus.sln
+++ b/Arcturus.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11222.15 d18.0
+VisualStudioVersion = 18.0.11222.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcturus.ResultObjects", "src\Arcturus.ResultObjects\Arcturus.ResultObjects.csproj", "{D6CC2DCE-65AF-457D-9736-04D939660A08}"
 EndProject
@@ -68,6 +68,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcturus.Xunit", "src\Arcturus.Xunit\Arcturus.Xunit.csproj", "{3C4F1409-9E0A-4326-A167-9B9913B31840}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcturus.Repository.EntityFrameworkCore.PostgresSql", "src\Arcturus.Repository.EntityFrameworkCore.PostgresSql\Arcturus.Repository.EntityFrameworkCore.PostgresSql.csproj", "{952CAA7C-72F7-42AA-970F-A9DE6552D84D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcturus.CodeAnalysis.CSharp", "src\Arcturus.CodeAnalysis.CSharp\Arcturus.CodeAnalysis.CSharp.csproj", "{877CF877-70D7-44D7-BCE6-F3DE62824C3D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -175,6 +177,10 @@ Global
 		{952CAA7C-72F7-42AA-970F-A9DE6552D84D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{952CAA7C-72F7-42AA-970F-A9DE6552D84D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{952CAA7C-72F7-42AA-970F-A9DE6552D84D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{877CF877-70D7-44D7-BCE6-F3DE62824C3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{877CF877-70D7-44D7-BCE6-F3DE62824C3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{877CF877-70D7-44D7-BCE6-F3DE62824C3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{877CF877-70D7-44D7-BCE6-F3DE62824C3D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Arcturus.CodeAnalysis.CSharp/AnalyzerReleases.Shipped.md
+++ b/src/Arcturus.CodeAnalysis.CSharp/AnalyzerReleases.Shipped.md
@@ -1,0 +1,7 @@
+## Release 1.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+SDA001 | Usage | Warning | Avoid direct HttpClient instantiation

--- a/src/Arcturus.CodeAnalysis.CSharp/AnalyzerReleases.Unshipped.md
+++ b/src/Arcturus.CodeAnalysis.CSharp/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,5 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+SDA001 | Usage | Warning | Avoid direct HttpClient instantiation

--- a/src/Arcturus.CodeAnalysis.CSharp/Arcturus.CodeAnalysis.CSharp.csproj
+++ b/src/Arcturus.CodeAnalysis.CSharp/Arcturus.CodeAnalysis.CSharp.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks></TargetFrameworks>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+		<IncludeBuildOutput>false</IncludeBuildOutput>
+
+		<IsPackable>true</IsPackable>
+		<DevelopmentDependency>true</DevelopmentDependency>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+		<!-- Package metadata -->
+		<PackageId>Arcturus.CodeAnalysis.CSharp</PackageId>
+		<PackageVersion>1.0.0</PackageVersion>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageTags>code analysis,arcturus</PackageTags>
+		<PackageIcon>nuget.png</PackageIcon>
+		<Authors>Arcturus</Authors>
+		<Description>Roslyn analyzers for safe development practices</Description>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+
+		<!-- Suppress expected analyzer package warning -->
+		<NoWarn>$(NoWarn);NU5128;RS1041</NoWarn>
+	</PropertyGroup>
+
+
+	<ItemGroup>
+		<!-- Use these analyzer-specific packages -->
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+		<AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- Include the analyzer DLL in the NuGet package -->
+		<None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+
+		<!-- Include README in the package -->
+		<None Include="README.md" Pack="true" PackagePath="\" />
+		<None Include="..\..\assets\nuget.png" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+</Project>

--- a/src/Arcturus.CodeAnalysis.CSharp/HttpClientInstantiationAnalyzer.cs
+++ b/src/Arcturus.CodeAnalysis.CSharp/HttpClientInstantiationAnalyzer.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
+
+namespace Arcturus.CodeAnalysis.CSharp;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class HttpClientInstantiationAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "SDA001";
+    private static readonly LocalizableString _title = "Avoid direct HttpClient instantiation";
+    private static readonly LocalizableString _messageFormat = "Directly creating HttpClient can lead to socket exhaustion. Use IHttpClientFactory or a shared instance instead.";
+    private static readonly LocalizableString _description = "Detects 'new HttpClient()' or 'using var x = new HttpClient();'.";
+    private const string _category = "Usage";
+
+    private static readonly DiagnosticDescriptor _rule = new (
+        DiagnosticId, _title, _messageFormat, _category, DiagnosticSeverity.Warning,
+        isEnabledByDefault: true, description: _description);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, SyntaxKind.ObjectCreationExpression);
+    }
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
+
+        var typeInfo = context.SemanticModel.GetTypeInfo(objectCreation);
+        if (typeInfo.Type?.ToDisplayString() == "System.Net.Http.HttpClient")
+        {
+            var diagnostic = Diagnostic.Create(_rule, objectCreation.GetLocation());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/Arcturus.CodeAnalysis.CSharp/README.md
+++ b/src/Arcturus.CodeAnalysis.CSharp/README.md
@@ -1,0 +1,104 @@
+# Arcturus.CodeAnalysis.CSharp
+
+A Roslyn analyzer package that provides code analysis rules to help enforce best practices and prevent common pitfalls in C# development.
+
+## Features
+
+This analyzer package currently includes the following diagnostic rules:
+
+- **SDA001: Avoid direct HttpClient instantiation** - Detects direct instantiation of `HttpClient` which can lead to socket exhaustion. Recommends using `IHttpClientFactory` or a shared instance instead.
+
+## Installation
+
+Install the package via NuGet Package Manager:
+
+```bash
+dotnet add package Arcturus.CodeAnalysis.CSharp
+```
+
+Or via Package Manager Console:
+
+```powershell
+Install-Package Arcturus.CodeAnalysis.CSharp
+```
+
+Or add it directly to your `.csproj` file:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Arcturus.CodeAnalysis.CSharp" Version="1.0.0" />
+</ItemGroup>
+```
+
+## Usage
+
+Once installed, the analyzers will automatically run during compilation and provide warnings or errors for detected issues in your code.
+
+### Example: HttpClient Instantiation
+
+**Bad Practice (will trigger SDA001 warning):**
+
+```csharp
+public class MyService
+{
+    public async Task<string> GetDataAsync()
+    {
+        var client = new HttpClient(); // Warning: Avoid direct HttpClient instantiation
+        return await client.GetStringAsync("https://api.example.com");
+    }
+}
+```
+
+**Recommended Approach:**
+
+```csharp
+public class MyService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public MyService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<string> GetDataAsync()
+    {
+        var client = _httpClientFactory.CreateClient();
+        return await client.GetStringAsync("https://api.example.com");
+    }
+}
+```
+
+## Diagnostic Rules
+
+| Rule ID | Category | Severity | Description |
+|---------|----------|----------|-------------|
+| SDA001  | Usage    | Warning  | Avoid direct HttpClient instantiation to prevent socket exhaustion |
+
+## Configuration
+
+You can configure the behavior of individual analyzers using an `.editorconfig` file in your project:
+
+```ini
+# Disable SDA001
+dotnet_diagnostic.SDA001.severity = none
+
+# Make SDA001 an error instead of warning
+dotnet_diagnostic.SDA001.severity = error
+
+# Keep as warning (default)
+dotnet_diagnostic.SDA001.severity = warning
+```
+
+## Requirements
+
+- .NET Standard 2.0 or higher
+- Compatible with .NET Framework 4.7.2+, .NET Core 2.0+, and .NET 5.0+
+
+## Contributing
+
+Contributions are welcome! If you have suggestions for new analyzer rules or improvements to existing ones, please open an issue or submit a pull request.
+
+## License
+
+This project is part of the Arcturus framework. Please refer to the main repository for license information.


### PR DESCRIPTION
Added Arcturus.CodeAnalysis.CSharp Roslyn analyzer project targeting .NET Standard 2.0. Implemented SDA001 rule to detect direct HttpClient instantiation and recommend using IHttpClientFactory. Updated solution file, added documentation (README, shipped/unshipped rules), and configured NuGet packaging for analyzers and docs.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
