### PR TITLE
Improve endpoint registration detection in generator

### DIFF
--- a/src/Arcturus.Validation.CodeGenerator/EndpointValidationGenerator.cs
+++ b/src/Arcturus.Validation.CodeGenerator/EndpointValidationGenerator.cs
@@ -109,7 +109,52 @@ public sealed class EndpointValidationGenerator : IIncrementalGenerator
 
     private static SyntaxNode? FindEndpointRegistration(InvocationExpressionSyntax validationInvocation)
     {
-        // Walk up the tree to find MapGet, MapPost, etc.
+        // For .AddEndpointFilter<ValidateParametersFilter>() or .ValidateParameters()
+        // The pattern is: app.MapGet(...).AddEndpointFilter<...>()
+        // We need to find the MapGet/MapPost/etc. invocation
+
+        // Check if this is a chained call (member access)
+        if (validationInvocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            // The expression part should be the previous call in the chain
+            var previousExpression = memberAccess.Expression;
+
+            // Keep traversing the chain to find the Map* method
+            while (previousExpression != null)
+            {
+                if (previousExpression is InvocationExpressionSyntax invoc)
+                {
+                    var methodName = GetMethodName(invoc);
+                    if (methodName?.StartsWith("Map") == true)
+                    {
+                        // Found MapGet, MapPost, etc. - get the handler argument
+                        if (invoc.ArgumentList.Arguments.Count >= 2)
+                        {
+                            var handlerArg = invoc.ArgumentList.Arguments[1].Expression;
+                            return handlerArg;
+                        }
+                    }
+
+                    // Check if this invocation is also a chain
+                    if (invoc.Expression is MemberAccessExpressionSyntax nextMember)
+                    {
+                        previousExpression = nextMember.Expression;
+                        continue;
+                    }
+                }
+
+                // Try member access
+                if (previousExpression is MemberAccessExpressionSyntax ma)
+                {
+                    previousExpression = ma.Expression;
+                    continue;
+                }
+
+                break;
+            }
+        }
+
+        // Fallback: Walk up the tree to find MapGet, MapPost, etc.
         var current = validationInvocation.Parent;
         while (current is not null)
         {
@@ -128,6 +173,7 @@ public sealed class EndpointValidationGenerator : IIncrementalGenerator
             }
             current = current.Parent;
         }
+
         return null;
     }
 


### PR DESCRIPTION
Enhanced FindEndpointRegistration to better locate original endpoint registrations (e.g., MapGet, MapPost) when chained with calls like .AddEndpointFilter or .ValidateParameters. The method now traverses member access and invocation chains to reliably extract the handler argument, improving support for various endpoint registration patterns. The original fallback tree-walking logic is still retained.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
