### PR TITLE
Add ASP.NET-style middleware pipeline for CLI apps

### DIFF
--- a/src/Arcturus.Extensions.CommandLine/Abstractions/CommandLineContext.cs
+++ b/src/Arcturus.Extensions.CommandLine/Abstractions/CommandLineContext.cs
@@ -1,0 +1,39 @@
+using System.CommandLine.Parsing;
+
+namespace Arcturus.CommandLine.Abstractions;
+
+/// <summary>
+/// Encapsulates all command-line specific information about an individual execution.
+/// </summary>
+public class CommandLineContext
+{
+    /// <summary>
+    /// Gets or sets the <see cref="IServiceProvider"/> that provides access to the application's service container.
+    /// </summary>
+    public required IServiceProvider Services { get; init; }
+
+    /// <summary>
+    /// Gets or sets the command-line arguments.
+    /// </summary>
+    public required string[] Args { get; init; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="Parser"/> for parsing command-line input.
+    /// </summary>
+    public required Parser Parser { get; init; }
+
+    /// <summary>
+    /// Gets or sets the <see cref="CancellationToken"/> for the execution.
+    /// </summary>
+    public CancellationToken CancellationToken { get; init; }
+
+    /// <summary>
+    /// Gets or sets the root command instance.
+    /// </summary>
+    public required ICommand RootCommand { get; init; }
+
+    /// <summary>
+    /// Gets a key/value collection that can be used to share data within the scope of this execution.
+    /// </summary>
+    public IDictionary<object, object?> Items { get; } = new Dictionary<object, object?>();
+}

--- a/src/Arcturus.Extensions.CommandLine/Abstractions/CommandLineDelegate.cs
+++ b/src/Arcturus.Extensions.CommandLine/Abstractions/CommandLineDelegate.cs
@@ -1,0 +1,8 @@
+namespace Arcturus.CommandLine.Abstractions;
+
+/// <summary>
+/// A function that can process a command-line execution.
+/// </summary>
+/// <param name="context">The <see cref="CommandLineContext"/> for the current execution.</param>
+/// <returns>A task that represents the completion of command processing.</returns>
+public delegate Task CommandLineDelegate(CommandLineContext context);

--- a/src/Arcturus.Extensions.CommandLine/Abstractions/ICommandLineMiddleware.cs
+++ b/src/Arcturus.Extensions.CommandLine/Abstractions/ICommandLineMiddleware.cs
@@ -1,0 +1,15 @@
+namespace Arcturus.CommandLine.Abstractions;
+
+/// <summary>
+/// Defines middleware for the command-line execution pipeline.
+/// </summary>
+public interface ICommandLineMiddleware
+{
+    /// <summary>
+    /// Request handling method.
+    /// </summary>
+    /// <param name="context">The <see cref="CommandLineContext"/> for the current execution.</param>
+    /// <param name="next">The delegate representing the remaining middleware in the pipeline.</param>
+    /// <returns>A <see cref="Task"/> that represents the execution of this middleware.</returns>
+    Task InvokeAsync(CommandLineContext context, CommandLineDelegate next);
+}

--- a/src/Arcturus.Extensions.CommandLine/Abstractions/OptionAttribute.cs
+++ b/src/Arcturus.Extensions.CommandLine/Abstractions/OptionAttribute.cs
@@ -5,6 +5,15 @@ public class OptionAttribute(
     string name
     , string? description) : Attribute
 {
+    public OptionAttribute(
+        string name
+        , string? description
+        , bool required) 
+        : this(name, description)
+    {
+        Required = required;
+    }
     public string Name => name;
     public string? Description => description;
+    public bool? Required { get; }
 }

--- a/src/Arcturus.Extensions.CommandLine/CliConsole.cs
+++ b/src/Arcturus.Extensions.CommandLine/CliConsole.cs
@@ -1,0 +1,108 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Arcturus.CommandLine;
+
+public static class CliConsole
+{
+    private static readonly Dictionary<string, ConsoleColor> ColorMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["black"] = ConsoleColor.Black,
+        ["darkblue"] = ConsoleColor.DarkBlue,
+        ["darkgreen"] = ConsoleColor.DarkGreen,
+        ["darkcyan"] = ConsoleColor.DarkCyan,
+        ["darkred"] = ConsoleColor.DarkRed,
+        ["darkmagenta"] = ConsoleColor.DarkMagenta,
+        ["darkyellow"] = ConsoleColor.DarkYellow,
+        ["gray"] = ConsoleColor.Gray,
+        ["darkgray"] = ConsoleColor.DarkGray,
+        ["blue"] = ConsoleColor.Blue,
+        ["green"] = ConsoleColor.Green,
+        ["cyan"] = ConsoleColor.Cyan,
+        ["red"] = ConsoleColor.Red,
+        ["magenta"] = ConsoleColor.Magenta,
+        ["yellow"] = ConsoleColor.Yellow,
+        ["white"] = ConsoleColor.White,
+    };
+
+    public static void Write(TextWriter writer, string text)
+    {
+        WriteMarkup(writer, text);
+    }
+    public static void WriteLine(TextWriter writer, string text)
+    {
+        WriteMarkup(writer, text + Environment.NewLine);
+    }
+    public static void Write(string text)
+    {
+        WriteMarkup(Console.Out, text);
+    }
+    public static void WriteLine(string text)
+    {
+        WriteMarkup(Console.Out, text + Environment.NewLine);
+    }
+
+    private static void WriteMarkup(TextWriter writer, string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        // Check if we can apply colors - console must be available and not redirected
+        var canApplyColors = !Console.IsOutputRedirected && !Console.IsErrorRedirected;
+
+        if (!canApplyColors)
+        {
+            // For redirected output or non-console writers, strip markup tags and write plain text
+            var pattern = @"\[(\/?[^\]]+)\]";
+            var plainText = Regex.Replace(text, pattern, string.Empty);
+            writer.Write(plainText);
+            return;
+        }
+
+        var originalColor = Console.ForegroundColor;
+        var colorStack = new Stack<ConsoleColor>();
+
+        var pattern2 = @"\[(\/?[^\]]+)\]";
+        var matches = Regex.Matches(text, pattern2);
+        var lastIndex = 0;
+
+        foreach (Match match in matches)
+        {
+            // Write text before the tag
+            if (match.Index > lastIndex)
+            {
+                writer.Write(text.Substring(lastIndex, match.Index - lastIndex));
+            }
+
+            var tag = match.Groups[1].Value;
+
+            if (tag == "/")
+            {
+                // Reset to previous color or original
+                Console.ForegroundColor = colorStack.Count > 0 ? colorStack.Pop() : originalColor;
+            }
+            else if (ColorMap.TryGetValue(tag, out var color))
+            {
+                colorStack.Push(Console.ForegroundColor);
+                Console.ForegroundColor = color;
+            }
+            else
+            {
+                // Not a recognized tag, write it as-is
+                writer.Write(match.Value);
+            }
+
+            lastIndex = match.Index + match.Length;
+        }
+
+        // Write remaining text
+        if (lastIndex < text.Length)
+        {
+            writer.Write(text.Substring(lastIndex));
+        }
+
+        // Reset color at the end
+        Console.ForegroundColor = originalColor;
+    }
+}

--- a/src/Arcturus.Extensions.CommandLine/HostBuilderExtensions.cs
+++ b/src/Arcturus.Extensions.CommandLine/HostBuilderExtensions.cs
@@ -15,8 +15,8 @@ public static class HostBuilderExtensions
         _configureCommandLineBuilder(commandLineBuilder);
     }
 
-    public static IHostBuilder ConfigureCommandLineBuilder(
-        this IHostBuilder builder
+    public static IHostApplicationBuilder ConfigureCommandLineBuilder(
+        this IHostApplicationBuilder builder
         , Action<CommandLineBuilder> configureAction)
     {
         _configureCommandLineBuilder = configureAction;

--- a/src/Arcturus.Extensions.CommandLine/HostExtensions.cs
+++ b/src/Arcturus.Extensions.CommandLine/HostExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Arcturus.CommandLine.Abstractions;
 using Arcturus.CommandLine.Internals;
+using Arcturus.Extensions.CommandLine.Internals;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System.CommandLine;
@@ -11,6 +12,28 @@ namespace Arcturus.CommandLine;
 
 public static class HostExtensions
 {
+    public static IHost UseHelp(
+        this IHost host, Action<System.CommandLine.Help.HelpContext> helpBuilder, int? maxWidth = null)
+    {
+        var config = host.Services.GetRequiredService<CommandLineBuilderConfiguration>();
+        config.AddConfiguration(builder => builder.UseHelp(helpBuilder, maxWidth));
+        return host;
+    }
+
+    /// <summary>
+    /// Adds a middleware type to the command-line execution pipeline.
+    /// </summary>
+    /// <typeparam name="TMiddleware">The middleware type.</typeparam>
+    /// <param name="host">The host instance.</param>
+    /// <returns>The host instance for chaining.</returns>
+    public static IHost UseMiddleware<TMiddleware>(this IHost host)
+        where TMiddleware : ICommandLineMiddleware
+    {
+        var config = host.Services.GetRequiredService<CommandLineBuilderConfiguration>();
+        config.AddMiddleware(typeof(TMiddleware));
+        return host;
+    }
+
     /// <summary>
     /// Run console using commands. <typeparamref name="T"/> serve as root.
     /// </summary>
@@ -30,13 +53,33 @@ public static class HostExtensions
         var commandLineCommand = new RootCommand(commandDetails?.Description ?? "CLI");
 
         CommandLineBuilder commandLineBuilder = new(commandLineCommand);
+        commandLineBuilder.UseDefaults();
+
+        // Apply any stored configurations
+        var config = host.Services.GetService<CommandLineBuilderConfiguration>();
+        config?.Apply(commandLineBuilder);
+
         HostBuilderExtensions.AssignCommandLineBuilder(commandLineBuilder);
 
         var parser = commandLineBuilder.Build();
         AssignCommandsRecrusive(command, commandLineCommand, host.Services, cancellationTokenSource.Token);
 
-        //await commandLineCommand.InvokeAsync(args);
-        await parser.InvokeAsync(args);
+        // Build and execute the middleware pipeline
+        var context = new CommandLineContext
+        {
+            Services = host.Services,
+            Args = args,
+            Parser = parser,
+            CancellationToken = cancellationTokenSource.Token,
+            RootCommand = command
+        };
+
+        var pipeline = BuildPipeline(config, async (ctx) =>
+        {
+            await ctx.Parser.InvokeAsync(ctx.Args);
+        });
+
+        await pipeline(context);
     }
 
     private static void AssignCommandsRecrusive(
@@ -45,75 +88,81 @@ public static class HostExtensions
         , IServiceProvider services
         , CancellationToken cancellationToken)
     {
-        var subCommandAttribute = parentCommand.GetType().GetCustomAttribute<SubCommandAttribute>();
-        if (subCommandAttribute is not null && subCommandAttribute.SubCommands?.Length > 0)
+        var subCommandAttributes = parentCommand.GetType().GetCustomAttributes<SubCommandAttribute>();
+        foreach (var subCommandAttribute in subCommandAttributes)
         {
-            foreach (var subCommandType in subCommandAttribute.SubCommands.OrderBy(_ => _.Name))
+        
+            //var subCommandAttribute = parentCommand.GetType().GetCustomAttribute<SubCommandAttribute>();
+            if (subCommandAttribute is not null && subCommandAttribute.SubCommands?.Length > 0)
             {
-                var command = (ICommand)Activator.CreateInstance(subCommandType)!;
-                var commandDetails = subCommandType.GetCustomAttribute<CommandAttribute>();
-                if (commandDetails is null)
-                    continue;
-
-                // create the system commandline command (wrapper)
-                var wrappedCommand = new Command(commandDetails.Name, commandDetails.Description);
-                //if (commandDetails.Aliases?.Length > 0)
-                //{
-                //    foreach (var alias in commandDetails.Aliases)
-                //    {
-                //        wrappedCommand.AddAlias(alias);
-                //    }
-                //}
-
-                foreach (var field in subCommandType
-                    .GetProperties()
-                    .Select(_ => (attr: _.GetCustomAttribute<OptionAttribute>(), pinfo: _!)).Where(_ => _.attr is not null))
+                foreach (var subCommandType in subCommandAttribute.SubCommands.OrderBy(_ => _.Name))
                 {
-                    // we use reflection to instanciate
-                    var option = CreateOptionInstance(
-                        field.pinfo.PropertyType, field.attr!.Name, field.attr?.Description);
-                    option.IsRequired = !Arcturus.CommandLine.Internals.TypeExtensions.IsNullable(field.pinfo.PropertyType);
+                    var command = (ICommand)Activator.CreateInstance(subCommandType)!;
+                    var commandDetails = subCommandType.GetCustomAttribute<CommandAttribute>();
+                    if (commandDetails is null)
+                        continue;
 
-                    wrappedCommand.AddOption(option);
-                }
+                    // create the system commandline command (wrapper)
+                    var wrappedCommand = new Command(commandDetails.Name, commandDetails.Description);
+                    //if (commandDetails.Aliases?.Length > 0)
+                    //{
+                    //    foreach (var alias in commandDetails.Aliases)
+                    //    {
+                    //        wrappedCommand.AddAlias(alias);
+                    //    }
+                    //}
 
-                // register handler
-                var handlerType = typeof(ICommandHandler<>).MakeGenericType(subCommandType);
-                var handler = services.GetService(handlerType);
-                if (handler is not null && handlerType.TryGetMethod("Handle", out var methodHandler))
-                {
-                    wrappedCommand.SetHandler(async (context) =>
+                    foreach (var field in subCommandType
+                        .GetProperties()
+                        .Select(_ => (attr: _.GetCustomAttribute<OptionAttribute>(), pinfo: _!)).Where(_ => _.attr is not null))
                     {
-                        //context.ParseResult.GetValueForOption()
-                        // context.ParseResult.CommandResult.Children
-                        foreach (var o in context.ParseResult.CommandResult.Command.Options)
+                        // we use reflection to instanciate
+                        var option = CreateOptionInstance(
+                            field.pinfo.PropertyType, field.attr!.Name, field.attr?.Description)!;
+                        option.IsRequired = !Internals.TypeExtensions.IsNullable(field.pinfo.PropertyType) || 
+                            Internals.TypeExtensions.IsRequired(field.pinfo);
+
+                        wrappedCommand.AddOption(option);
+                    }
+
+                    // register handler
+                    var handlerType = typeof(ICommandHandler<>).MakeGenericType(subCommandType);
+                    var handler = services.GetService(handlerType);
+                    if (handler is not null && handlerType.TryGetMethod("Handle", out var methodHandler))
+                    {
+                        wrappedCommand.SetHandler(async (context) =>
                         {
-                            var ov = context.ParseResult.GetValueForOption(o);
-
-                            var property = subCommandType
-                                .GetProperties()
-                                .Where(_ => _.GetCustomAttribute<OptionAttribute>()?.Name == "--" + o.Name)
-                                .FirstOrDefault();
-                            if (property is not null)
+                            //context.ParseResult.GetValueForOption()
+                            // context.ParseResult.CommandResult.Children
+                            foreach (var o in context.ParseResult.CommandResult.Command.Options)
                             {
-                                if (Arcturus.CommandLine.Internals.TypeExtensions.IsEnumOrNullableEnum(property.PropertyType))
+                                var ov = context.ParseResult.GetValueForOption(o);
+
+                                var property = subCommandType
+                                    .GetProperties()
+                                    .Where(_ => _.GetCustomAttribute<OptionAttribute>()?.Name == "--" + o.Name)
+                                    .FirstOrDefault();
+                                if (property is not null)
                                 {
-                                    ov = Enum.Parse(
-                                        Arcturus.CommandLine.Internals.TypeExtensions.GetEnumType(property.PropertyType)
-                                        , ov.ToString(), true);
+                                    if (Arcturus.CommandLine.Internals.TypeExtensions.IsEnumOrNullableEnum(property.PropertyType))
+                                    {
+                                        ov = Enum.Parse(
+                                            Arcturus.CommandLine.Internals.TypeExtensions.GetEnumType(property.PropertyType)
+                                            , ov.ToString(), true);
+                                    }
+                                    property.SetValue(command, ov);
                                 }
-                                property.SetValue(command, ov);
                             }
-                        }
-                        await (ValueTask)methodHandler!.Invoke(handler, [command!, cancellationToken])!;
-                    });
+                            await (ValueTask)methodHandler!.Invoke(handler, [command!, cancellationToken])!;
+                        });
+                    }
+                    commandLineCommand.AddCommand(wrappedCommand);
+
+                    AssignCommandsRecrusive(command, wrappedCommand, services, cancellationToken);
                 }
-                commandLineCommand.AddCommand(wrappedCommand);
-
-                AssignCommandsRecrusive(command, wrappedCommand, services, cancellationToken);
             }
-        }
 
+        }
     }
     private static Option CreateOptionInstance(Type typeArg, string name, string? description)
     {
@@ -130,5 +179,30 @@ public static class HostExtensions
 
         // Create instance using the constructor
         return (Option)ctor.Invoke([name, description]);
+    }
+
+    private static CommandLineDelegate BuildPipeline(
+        CommandLineBuilderConfiguration? config,
+        CommandLineDelegate finalHandler)
+    {
+        if (config == null)
+            return finalHandler;
+
+        var middlewareTypes = config.GetMiddlewareTypes().Reverse().ToList();
+
+        CommandLineDelegate pipeline = finalHandler;
+
+        foreach (var middlewareType in middlewareTypes)
+        {
+            var next = pipeline;
+            pipeline = context =>
+            {
+                var middleware = (ICommandLineMiddleware)ActivatorUtilities.CreateInstance(
+                    context.Services, middlewareType);
+                return middleware.InvokeAsync(context, next);
+            };
+        }
+
+        return pipeline;
     }
 }

--- a/src/Arcturus.Extensions.CommandLine/Internals/CommandLineBuilderConfiguration.cs
+++ b/src/Arcturus.Extensions.CommandLine/Internals/CommandLineBuilderConfiguration.cs
@@ -1,0 +1,29 @@
+﻿using System.CommandLine.Builder;
+
+namespace Arcturus.Extensions.CommandLine.Internals;
+
+internal class CommandLineBuilderConfiguration
+{
+    private readonly List<Action<CommandLineBuilder>> _configurations = [];
+    private readonly List<Type> _middlewareTypes = [];
+
+    internal void AddConfiguration(Action<CommandLineBuilder> configure)
+    {
+        _configurations.Add(configure);
+    }
+
+    internal void Apply(CommandLineBuilder builder)
+    {
+        foreach (var configure in _configurations)
+        {
+            configure(builder);
+        }
+    }
+
+    internal void AddMiddleware(Type middlewareType)
+    {
+        _middlewareTypes.Add(middlewareType);
+    }
+
+    internal IEnumerable<Type> GetMiddlewareTypes() => _middlewareTypes;
+}

--- a/src/Arcturus.Extensions.CommandLine/Internals/TypeExtensions.cs
+++ b/src/Arcturus.Extensions.CommandLine/Internals/TypeExtensions.cs
@@ -22,4 +22,22 @@ internal static class TypeExtensions
     {
         return type.IsEnum ? type : Nullable.GetUnderlyingType(type)!;
     }
+    internal static bool IsRequired(this PropertyInfo property)
+    {
+        return property.GetCustomAttribute<System.Runtime.CompilerServices.RequiredMemberAttribute>() is not null;
+    }
+
+    internal static bool IsNullableReferenceType(this PropertyInfo property)
+    {
+        var context = new NullabilityInfoContext();
+        var nullability = context.Create(property);
+        return nullability.WriteState == NullabilityState.Nullable;
+    }
+
+    internal static bool IsNullableReferenceType(this ParameterInfo parameter)
+    {
+        var context = new NullabilityInfoContext();
+        var nullability = context.Create(parameter);
+        return nullability.WriteState == NullabilityState.Nullable;
+    }
 }

--- a/src/Arcturus.Extensions.CommandLine/MIDDLEWARE.md
+++ b/src/Arcturus.Extensions.CommandLine/MIDDLEWARE.md
@@ -1,0 +1,147 @@
+# Command-Line Middleware Pipeline
+
+This implementation provides an ASP.NET-like middleware pipeline for command-line applications.
+
+## Usage
+
+### 1. Create a Middleware
+
+Implement the `ICommandLineMiddleware` interface:
+
+```csharp
+using Arcturus.CommandLine.Abstractions;
+using Microsoft.Extensions.Logging;
+
+public class TimingMiddleware : ICommandLineMiddleware
+{
+    private readonly ILogger<TimingMiddleware> _logger;
+
+    public TimingMiddleware(ILogger<TimingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(CommandLineContext context, CommandLineDelegate next)
+    {
+        var sw = Stopwatch.StartNew();
+        
+        _logger.LogInformation("Command started: {Args}", string.Join(" ", context.Args));
+        
+        await next(context);
+        
+        sw.Stop();
+        _logger.LogInformation("Command completed in {ElapsedMs}ms", sw.ElapsedMilliseconds);
+    }
+}
+```
+
+### 2. Register Middleware
+
+Use the `UseMiddleware<T>()` extension method on your `IHost`:
+
+```csharp
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        // Register your commands and handlers
+        services.AddCommandLine();
+    })
+    .Build();
+
+// Register middleware
+host.UseMiddleware<LoggingMiddleware>()
+    .UseMiddleware<TimingMiddleware>()
+    .UseMiddleware<ExceptionHandlingMiddleware>();
+
+// Run the command-line application
+await host.RunConsoleCommands<RootCommand>(args);
+```
+
+### 3. Access Context in Middleware
+
+The `CommandLineContext` provides access to:
+
+- **Services**: The DI service provider
+- **Args**: Command-line arguments
+- **Parser**: The System.CommandLine parser
+- **CancellationToken**: Cancellation token for the execution
+- **RootCommand**: The root command instance
+- **Items**: A dictionary for sharing data between middleware
+
+```csharp
+public async Task InvokeAsync(CommandLineContext context, CommandLineDelegate next)
+{
+    // Store data in context
+    context.Items["StartTime"] = DateTime.UtcNow;
+    
+    // Access services
+    var myService = context.Services.GetRequiredService<IMyService>();
+    
+    await next(context);
+    
+    // Retrieve data from context
+    var startTime = (DateTime)context.Items["StartTime"]!;
+}
+```
+
+## Built-in Middleware
+
+### LoggingMiddleware
+
+Logs command execution timing and exceptions:
+
+```csharp
+host.UseMiddleware<LoggingMiddleware>();
+```
+
+## Middleware Execution Order
+
+Middleware is executed in the order it is registered. Each middleware can:
+
+1. Execute code **before** the next middleware
+2. Call `await next(context)` to invoke the next middleware
+3. Execute code **after** the next middleware returns
+
+```
+Request Flow:
+│
+├─> Middleware 1 (before)
+│   ├─> Middleware 2 (before)
+│   │   ├─> Middleware 3 (before)
+│   │   │   └─> Command Execution
+│   │   └─> Middleware 3 (after)
+│   └─> Middleware 2 (after)
+└─> Middleware 1 (after)
+```
+
+## Example: Exception Handling Middleware
+
+```csharp
+public class ExceptionHandlingMiddleware : ICommandLineMiddleware
+{
+    private readonly ILogger<ExceptionHandlingMiddleware> _logger;
+
+    public ExceptionHandlingMiddleware(ILogger<ExceptionHandlingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(CommandLineContext context, CommandLineDelegate next)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (ValidationException ex)
+        {
+            _logger.LogError("Validation error: {Message}", ex.Message);
+            Environment.ExitCode = 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception occurred");
+            Environment.ExitCode = 1;
+        }
+    }
+}
+```

--- a/src/Arcturus.Extensions.CommandLine/README.md
+++ b/src/Arcturus.Extensions.CommandLine/README.md
@@ -7,6 +7,8 @@
 
 Arcturus.Extensions.CommandLine is a .NET library that simplifies the creation and parsing of command-line interfaces for .NET applications. It provides a flexible API for defining commands, options, and arguments, enabling robust and user-friendly CLI tools.
 
+The package use - https://learn.microsoft.com/en-us/dotnet/standard/commandline/how-to-customize-help
+
 ## Installation
 
 Install the package via NuGet Package Manager or the .NET CLI:

--- a/src/Arcturus.Extensions.CommandLine/ServiceCollectionExtensions.cs
+++ b/src/Arcturus.Extensions.CommandLine/ServiceCollectionExtensions.cs
@@ -1,10 +1,22 @@
 ﻿using Arcturus.CommandLine.Abstractions;
+using Arcturus.Extensions.CommandLine.Internals;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Arcturus.CommandLine;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="services"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddCommandLine(this IServiceCollection services)
+    {
+        services.AddSingleton<CommandLineBuilderConfiguration>();
+        AutoRegisterCommandHandlers(services);
+        return services;
+    }
     /// <summary>
     /// Registers all command handlers in the executing assembly.
     /// <para>
@@ -14,7 +26,7 @@ public static class ServiceCollectionExtensions
     /// <param name="services">Required.</param>
     /// <param name="serviceLifetime">Specifies the <see cref="ServiceLifetime"/> of each command handler.</param>
     /// <returns><see cref="IServiceCollection"/></returns>
-    public static IServiceCollection AutoRegisterCommandHandlers(
+    private static IServiceCollection AutoRegisterCommandHandlers(
         this IServiceCollection services, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
     {
         var handlerTypes = AppDomain.CurrentDomain.GetAssemblies()

--- a/src/Arcturus.Extensions.ResultObjects.AspNetCore/Internals/FallbackProblemDetailsWriter.cs
+++ b/src/Arcturus.Extensions.ResultObjects.AspNetCore/Internals/FallbackProblemDetailsWriter.cs
@@ -12,6 +12,8 @@ internal class FallbackProblemDetailsWriter
 
         // json options are not used here because the default json options are configured by the framework
         // when writing WriteAsJsonAsync, and we want to be consistent with that.
+        httpContext.Response.ContentType = "application/problem+json; charset=utf-8";
+        httpContext.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status500InternalServerError;
         return httpContext.Response.WriteAsJsonAsync<ProblemDetails>(problemDetails);
     }
 }


### PR DESCRIPTION
Introduces a command-line middleware pipeline inspired by ASP.NET Core, enabling registration and execution of middleware components for CLI applications. Adds abstractions for CommandLineContext, CommandLineDelegate, and ICommandLineMiddleware. Includes CommandLineBuilderConfiguration for managing builder and middleware configuration. Adds extension methods to IHost for UseHelp and UseMiddleware<T>. Updates RunConsoleCommands to execute the middleware pipeline. Enhances option reflection with required/nullable detection. Adds colored console output utility (CliConsole). Updates documentation and improves command-line builder configuration.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
