### PR TITLE
Add ConnectionString support and update RabbitMQ client

### DIFF
--- a/src/Arcturus.EventBus.Abstracts/IProcessor.cs
+++ b/src/Arcturus.EventBus.Abstracts/IProcessor.cs
@@ -11,10 +11,16 @@ public interface IProcessor
     event Func<IEventMessage, OnProcessEventArgs?, Task> OnProcessAsync;
 
     /// <summary>
-    /// Waits for events to be processed.
+    /// Waits for events to be processed. This method should be called to start the event processing loop and will continue to run until the provided cancellation token is triggered.
     /// </summary>
     /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <remarks>
+    /// It is recommended to start this using a long-running task, such as:
+    /// <code>
+    /// Task.Run(() => processor.WaitForEvents(cancellationToken), TaskCreationOptions.LongRunning);
+    /// </code>
+    /// </remarks>
     Task WaitForEvents(
         CancellationToken cancellationToken = default);
 }

--- a/src/Arcturus.EventBus.RabbitMQ/Arcturus.EventBus.RabbitMQ.csproj
+++ b/src/Arcturus.EventBus.RabbitMQ/Arcturus.EventBus.RabbitMQ.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="RabbitMQ.Client" Version="7.2.0" />
+	  <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
 	  <PackageReference Include="Polly" Version="8.6.5" />
 	  <PackageReference Include="OpenTelemetry.Api" Version="1.15.0" />
 	</ItemGroup>

--- a/src/Arcturus.EventBus.RabbitMQ/RabbitMQConnection.cs
+++ b/src/Arcturus.EventBus.RabbitMQ/RabbitMQConnection.cs
@@ -23,13 +23,24 @@ public sealed class RabbitMQConnection : IConnection
     {
         _applicationId = options.ApplicationId;
         _clientName = options.ClientName ?? Environment.MachineName;
-        _connectionHostName = options.HostName ?? "localhost";
+        _connectionHostName = options.ConnectionString ?? "localhost";
     }
 
     internal async Task Connect(CancellationToken cancellationToken = default)
     {
-        var factory = new RMQ.ConnectionFactory { HostName = _connectionHostName };
+        var factory = new RMQ.ConnectionFactory();
 
+        // Check if HostName is a URI
+        if (Uri.TryCreate(_connectionHostName, UriKind.Absolute, out var uri))
+        {
+            factory.Uri = uri;
+        }
+        else
+        {
+            factory.HostName = _connectionHostName;
+        }
+
+        factory.ClientProvidedName = _clientName;
         using (await _asyncLock.LockAsync(cancellationToken))
         {
             _connection = await factory.CreateConnectionAsync(_clientName, cancellationToken);

--- a/src/Arcturus.EventBus.RabbitMQ/RabbitMQEventBusOptions.cs
+++ b/src/Arcturus.EventBus.RabbitMQ/RabbitMQEventBusOptions.cs
@@ -17,7 +17,12 @@ public sealed class RabbitMQEventBusOptions
     /// <summary>
     /// Gets or sets a host name. Defaults to localhost.
     /// </summary>
+    [Obsolete("HostName is deprecated. Use ConnectionString instead.")]
     public string? HostName { get; set; }
+    /// <summary>
+    /// Gets or sets the amqps:// connection string. If provided, it will override the HostName property.
+    /// </summary>
+    public string? ConnectionString { get; set; }
     /// <summary>
     /// If true, events will be processed by the <see cref="Arcturus.EventBus.EventHandlersProcessor"/> or fallback to the <see cref="Arcturus.EventBus.Abstracts.IProcessor.OnProcessAsync"/> event.
     /// </summary>


### PR DESCRIPTION
- Added ConnectionString property to RabbitMQEventBusOptions for full AMQP(S) URI support; marked HostName as obsolete.
- Updated RabbitMQConnection to prefer ConnectionString and support both URI and hostname connection methods.
- Upgraded RabbitMQ.Client dependency to 7.2.1.
- Improved WaitForEvents documentation in IProcessor with usage guidance.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
