### PR TITLE
Refactor EventTypeRegistry for logging and faster lookups

### DIFF
--- a/src/Arcturus.EventBus/EventTypeRegistry.cs
+++ b/src/Arcturus.EventBus/EventTypeRegistry.cs
@@ -10,14 +10,14 @@ internal sealed record EventHandlerEntry(Type HandlerType, Type EventHandlerInte
 
 public sealed class EventTypeRegistry // singleton
 {
-    private readonly ILogger<EventTypeRegistry> _logger;
+    private readonly ILogger<EventTypeRegistry>? _logger;
     private readonly Lazy<Dictionary<string, Type>> _typesByName;
     private readonly Lazy<Dictionary<Type, string>> _namesByType;
     private readonly Lazy<Dictionary<Type, EventHandlerEntry>> _handlerMap;
 
-    internal EventTypeRegistry(ILoggerFactory loggerFactory, IReadOnlyCollection<Assembly> assemblies)
+    internal EventTypeRegistry(ILoggerFactory? loggerFactory, IReadOnlyCollection<Assembly> assemblies)
     {
-        _logger = loggerFactory.CreateLogger<EventTypeRegistry>();
+        _logger = loggerFactory?.CreateLogger<EventTypeRegistry>();
 
         // Built once at startup: event type → pre-computed handler entry (no runtime reflection).
         _handlerMap = new Lazy<Dictionary<Type, EventHandlerEntry>>(() =>
@@ -35,7 +35,9 @@ public sealed class EventTypeRegistry // singleton
                     var eventType = handlerInterface.GenericTypeArguments[0];
                     var handleMethod = handlerInterface.GetMethod(nameof(IEventMessageHandler<IEventMessage>.Handle))!;
 
-                    _logger.LogDebug($"Registering handler {handlerType.FullName} for event type {eventType.FullName}");
+                    _logger?.LogDebug(
+                        "Registering handler {FullName} for event type {EventTypeFullName}"
+                        , handlerType.FullName, eventType.FullName);
                     // First registration wins when multiple handlers target the same event type.
                     map.TryAdd(eventType, new EventHandlerEntry(handlerType, handlerInterface, handleMethod));
                 }
@@ -55,7 +57,7 @@ public sealed class EventTypeRegistry // singleton
             {
                 foreach (var (name, type) in Internals.AssemblyExtensions.GetEventMessageTypesFromAssembly(assembly))
                 {
-                    _logger.LogDebug($"Registering event message {name} with type {type.FullName}");
+                    _logger?.LogDebug("Registering event message {Name} with type {TypeFullName}", name, type.FullName);
                     byName.TryAdd(name, type);
                     byType.TryAdd(type, name);
                 }

--- a/src/Arcturus.EventBus/ServiceExtensions.cs
+++ b/src/Arcturus.EventBus/ServiceExtensions.cs
@@ -34,7 +34,7 @@ public static class ServiceExtensions
 
         // registry
         services.TryAddSingleton<EventTypeRegistry>((sp) => new EventTypeRegistry(
-            sp.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>()
+            sp.GetService<Microsoft.Extensions.Logging.ILoggerFactory>()
             , builder.ScanAllAssemblies 
                 ? Internals.AssemblyExtensions.LoadAllAssemblies()
                 : builder.AssembliesToScan));


### PR DESCRIPTION
- Add ILoggerFactory to EventTypeRegistry for debug logging of registrations.
- Replace internal event registry with dictionaries for O(1) lookups.
- Avoid redundant assembly scans by sharing initialization logic.
- Simplify GetTypeByName/GetNameByType; remove EventTypeEntry.
- Supplement event type/name mappings with handler-discovered types.
- Update DI registration to inject ILoggerFactory.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [x] I have added tests, or done manual regression tests
- [x] I have updated the documentation, if necessary
