### PR TITLE
Update to .NET 10.0, latest deps, and simplify projects

### DIFF
--- a/samples/Arcturus.Eventbus.Sample/Arcturus.EventBus.Sample.csproj
+++ b/samples/Arcturus.Eventbus.Sample/Arcturus.EventBus.Sample.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
 	</ItemGroup>
 </Project>

--- a/samples/Arcturus.Mediation.Sample/Arcturus.Mediation.Sample.csproj
+++ b/samples/Arcturus.Mediation.Sample/Arcturus.Mediation.Sample.csproj
@@ -13,8 +13,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
 	</ItemGroup>
 
 </Project>

--- a/src/Arcturus.Data.Repository.EntityFrameworkCore/Arcturus.Repository.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Arcturus.Data.Repository.EntityFrameworkCore/Arcturus.Repository.EntityFrameworkCore.SqlServer.csproj
@@ -10,10 +10,7 @@
 		<Description>Entity Framework Core (SQL Server) implementation of the Arcturus repository abstractions.</Description>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.14" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
 	</ItemGroup>
 

--- a/src/Arcturus.DevHost/Arcturus.DevHost.Hosting/Arcturus.DevHost.Hosting.csproj
+++ b/src/Arcturus.DevHost/Arcturus.DevHost.Hosting/Arcturus.DevHost.Hosting.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.4" />
+	  <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Arcturus.EventBus.AzureServiceBus/Arcturus.EventBus.AzureServiceBus.csproj
+++ b/src/Arcturus.EventBus.AzureServiceBus/Arcturus.EventBus.AzureServiceBus.csproj
@@ -11,14 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
 		<PackageReference Include="Polly" Version="8.6.6" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.15.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.15.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Arcturus.EventBus.AzureStorageQueue/Arcturus.EventBus.AzureStorageQueue.csproj
+++ b/src/Arcturus.EventBus.AzureStorageQueue/Arcturus.EventBus.AzureStorageQueue.csproj
@@ -10,14 +10,8 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
 		<PackageReference Include="Polly" Version="8.6.6" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.15.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.15.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Arcturus.EventBus.OpenTelemetry/Arcturus.EventBus.OpenTelemetry.csproj
+++ b/src/Arcturus.EventBus.OpenTelemetry/Arcturus.EventBus.OpenTelemetry.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OpenTelemetry.Api" Version="1.15.0" />
+		<PackageReference Include="OpenTelemetry.Api" Version="1.15.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Arcturus.EventBus.RabbitMQ/Arcturus.EventBus.RabbitMQ.csproj
+++ b/src/Arcturus.EventBus.RabbitMQ/Arcturus.EventBus.RabbitMQ.csproj
@@ -10,16 +10,8 @@
 	<ItemGroup>
 	  <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
 	  <PackageReference Include="Polly" Version="8.6.6" />
-	  <PackageReference Include="OpenTelemetry.Api" Version="1.15.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-		<ProjectReference Include="..\Arcturus.EventBus\Arcturus.EventBus.csproj" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
-		<ProjectReference Include="..\Arcturus.EventBus\Arcturus.EventBus.csproj" />
+	  <PackageReference Include="OpenTelemetry.Api" Version="1.15.2" />
+	  <ProjectReference Include="..\Arcturus.EventBus\Arcturus.EventBus.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Arcturus.EventBus.Sqlite/Arcturus.EventBus.Sqlite.csproj
+++ b/src/Arcturus.EventBus.Sqlite/Arcturus.EventBus.Sqlite.csproj
@@ -8,13 +8,9 @@
 		<PackageIcon>nuget.png</PackageIcon>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.4" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.4" />
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.5" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Arcturus.EventBus/Arcturus.EventBus.csproj
+++ b/src/Arcturus.EventBus/Arcturus.EventBus.csproj
@@ -7,14 +7,10 @@
 		<Description>A lightweight, extensible event bus library for .NET applications, enabling decoupled event publishing and handling with support for dependency injection and hosting integration.</Description>
 		<PackageIcon>nuget.png</PackageIcon>
 	</PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.2" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.4" />
+	
+	<ItemGroup>
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Arcturus.Extensions.Caching.AzureStorageTable/Arcturus.Extensions.Caching.AzureStorageTable.csproj
+++ b/src/Arcturus.Extensions.Caching.AzureStorageTable/Arcturus.Extensions.Caching.AzureStorageTable.csproj
@@ -8,8 +8,8 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Azure.Data.Tables" Version="12.11.0" />
-	  <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.4" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
+	  <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Arcturus.Extensions.Caching/Arcturus.Extensions.Caching.csproj
+++ b/src/Arcturus.Extensions.Caching/Arcturus.Extensions.Caching.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.4" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
 
 	</ItemGroup>
 	<ItemGroup>

--- a/src/Arcturus.Extensions.CommandLine/Arcturus.Extensions.CommandLine.csproj
+++ b/src/Arcturus.Extensions.CommandLine/Arcturus.Extensions.CommandLine.csproj
@@ -9,14 +9,9 @@
 		<Description>Lightweight utilities for building, grouping, and configuring command-line interfaces with minimal boilerplate. Works with .NET applications, promoting clear command structure, DI-friendly handlers, and discoverable command registration.</Description>
 	</PropertyGroup>
 
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-		<PackageReference Include="System.CommandLine" Version="2.0.4" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-		<PackageReference Include="System.CommandLine" Version="2.0.4" />
+		<PackageReference Include="System.CommandLine" Version="2.0.5" />
 	</ItemGroup>
 
 	<Target Name="IncludeXmlDocsInPackage" AfterTargets="Build">

--- a/src/Arcturus.Extensions.Configuration.AzureStorageBlob/Arcturus.Extensions.Configuration.AzureStorageBlob.csproj
+++ b/src/Arcturus.Extensions.Configuration.AzureStorageBlob/Arcturus.Extensions.Configuration.AzureStorageBlob.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/src/Arcturus.Extensions.ResultObjects.AspNetCore/Startup/ApplicationBuilderExtensions.cs
+++ b/src/Arcturus.Extensions.ResultObjects.AspNetCore/Startup/ApplicationBuilderExtensions.cs
@@ -20,6 +20,8 @@ public static class ApplicationBuilderExtensions
         this IApplicationBuilder app
         , Func<HttpContext, Exception, bool>? onExceptionEvent = null)
     {
-        return app.UseMiddleware<UnhandledExceptionMiddleware>(onExceptionEvent);
+        if (onExceptionEvent is not null)
+            return app.UseMiddleware<UnhandledExceptionMiddleware>(onExceptionEvent);
+        return app.UseMiddleware<UnhandledExceptionMiddleware>();
     }
 }

--- a/src/Arcturus.Mediation/Arcturus.Mediation.csproj
+++ b/src/Arcturus.Mediation/Arcturus.Mediation.csproj
@@ -25,8 +25,8 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.4" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
 	</ItemGroup>
 	
 </Project>

--- a/src/Arcturus.Repository.EntityFrameworkCore.NamingConvention/Arcturus.Repository.EntityFrameworkCore.NamingConvention.csproj
+++ b/src/Arcturus.Repository.EntityFrameworkCore.NamingConvention/Arcturus.Repository.EntityFrameworkCore.NamingConvention.csproj
@@ -21,15 +21,9 @@
 		<None Include="..\..\assets\nuget.png" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' != 'net10.0' ">
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.14" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.4" />
-	</ItemGroup>
-	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
 	</ItemGroup>
 
 </Project>

--- a/src/Arcturus.Repository.EntityFrameworkCore.PostgresSql/Arcturus.Repository.EntityFrameworkCore.PostgresSql.csproj
+++ b/src/Arcturus.Repository.EntityFrameworkCore.PostgresSql/Arcturus.Repository.EntityFrameworkCore.PostgresSql.csproj
@@ -9,11 +9,8 @@
 		<Description>Entity Framework Core (PostgreSQL) implementation of the Arcturus repository abstractions.</Description>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+	<ItemGroup>
 		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Arcturus.Xunit/Arcturus.Xunit.csproj
+++ b/src/Arcturus.Xunit/Arcturus.Xunit.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Xunit.DependencyInjection" Version="11.2.0" />
+	  <PackageReference Include="Xunit.DependencyInjection" Version="11.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
Dropped .NET 9.0 support and now target only .NET 10.0 across all projects. Updated Microsoft.Extensions.*, OpenTelemetry.Api, System.CommandLine, and other dependencies to their latest versions. Consolidated EF Core provider references to 10.x. Improved UseUnhandledExceptionHandler extension for cleaner middleware usage. Removed legacy and conditional project file logic for a simpler, modernized codebase.

### Summary & Motivation

A brief description of the changes in this pull request explaining why these changes are necessary. Please delete this paragraph.

### Checklist

- [ ] I have added tests, or done manual regression tests
- [ ] I have updated the documentation, if necessary
